### PR TITLE
#159987417 Users should be able to bookmark articles for reading later

### DIFF
--- a/server/helpers/helpers.js
+++ b/server/helpers/helpers.js
@@ -152,7 +152,7 @@ const helpers = {
       });
     });
   },
-
+  
   /**
    * @description Converts a string separated by spaces to an array of integers found in the string
    * @param  {srtring} str A string containing integers

--- a/server/helpers/helpers.js
+++ b/server/helpers/helpers.js
@@ -152,7 +152,6 @@ const helpers = {
       });
     });
   },
-  
   /**
    * @description Converts a string separated by spaces to an array of integers found in the string
    * @param  {srtring} str A string containing integers

--- a/server/migrations/20180830135814-create-users.js
+++ b/server/migrations/20180830135814-create-users.js
@@ -29,8 +29,7 @@ module.exports = {
       type: Sequelize.STRING
     },
     image: {
-      type: Sequelize.STRING,
-      defaultValue: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1536757459/dummy-profile.png'
+      type: Sequelize.STRING
     },
     premium: {
       type: Sequelize.BOOLEAN

--- a/server/migrations/20180913075318-create-bookmarks.js
+++ b/server/migrations/20180913075318-create-bookmarks.js
@@ -1,0 +1,40 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Bookmarks', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    title: {
+      type: Sequelize.STRING
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      }
+    },
+    articleId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Articles',
+        key: 'id',
+        as: 'articleId'
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }, { freezeTableName: true }),
+  down: queryInterface => queryInterface.dropTable('Bookmarks')
+};

--- a/server/models/bookmarks.js
+++ b/server/models/bookmarks.js
@@ -1,0 +1,24 @@
+const bookmarks = (sequelize, DataTypes) => {
+  const Bookmarks = sequelize.define('Bookmarks', {
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false
+    }
+  });
+
+  Bookmarks.associate = (models) => {
+    Bookmarks.belongsTo(models.Users, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE'
+    });
+
+    Bookmarks.belongsTo(models.Articles, {
+      foreignKey: 'articleId',
+      as: 'articles'
+    });
+  };
+
+  return Bookmarks;
+};
+
+export default bookmarks;

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -23,7 +23,9 @@ const {
   like,
   getArticles,
   getFeaturedArticles,
-  getPopularArticlesForTheWeek
+  getPopularArticlesForTheWeek,
+  createBookmark,
+  fetchBookmark
 } = articleController;
 const { addComment, updateComment, updateReply } = commentController;
 const {
@@ -122,5 +124,11 @@ articleRoutes.post(
 articleRoutes.get('/search', searchController);
 articleRoutes.get('/featured', getFeaturedArticles);
 articleRoutes.get('/popular', getPopularArticlesForTheWeek);
+
+// CREATE BOOKMARK ROUTE
+articleRoutes.post('/bookmarks/add/:articleId', auth, createBookmark);
+
+// GET ALL THE BOOKMARKS OF A USER
+articleRoutes.get('/bookmarks/user/all', auth, fetchBookmark);
 
 export default articleRoutes;

--- a/swagger.json
+++ b/swagger.json
@@ -1722,216 +1722,210 @@
         }
       }
     },
-    "ArticleRequestBody": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "example": "How the Metis ruled the world"
-        },
-        "slug": {
-          "type": "string",
-          "example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
-        },
-        "description": {
-          "type": "string",
-          "example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
-        },
-        "body": {
-          "type": "string",
-          "example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
-        },
-        "image": {
-          "type": "string",
-          "example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
-        }
-      }
-    },
-    "ArticleResponseBody": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "example": "How the Metis ruled the world"
-        },
-        "slug": {
-          "type": "string",
-          "example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
-        },
-        "description": {
-          "type": "string",
-          "example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
-        },
-        "body": {
-          "type": "string",
-          "example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
-        },
-        "image": {
-          "type": "string",
-          "example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "datetime",
-          "example": "2018-09-05T00:00:00.000Z"
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "datetime",
-          "example": "2018-09-05T00:00:00.000Z"
-        }
-      }
-    },
-    "ArticlesResponseBody": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "string",
-          "example": "success"
-        },
-        "data": {
-          "type": "object",
-          "properties": {
-            "articles": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ArticleResponseBody"
-              }
-            },
-            "currentPage": {
-              "type": "integer",
-              "example": 1
-            }
-          }
-        }
-      }
-    },
-    "Update": {
-      "type": "object",
-      "properties": {
-        "firstname": {
-          "type": "string",
-          "example": "joe"
-        },
-        "lastname": {
-          "type": "string",
-          "example": "easy"
-        },
-        "username": {
-          "type": "string",
-          "example": "metis"
-        },
-        "email": {
-          "type": "string",
-          "example": "metis@gmail.com"
-        },
-        "password": {
-          "type": "string",
-          "example": "password"
-        },
-        "bio": {
-          "type": "string",
-          "example": "Here is a brief information about me"
-        },
-        "interest": {
-          "type": "array",
-          "example": [
-            "gaming",
-            "entreprenuership"
-          ]
-        }
+		"ArticleRequestBody": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string",
+					"example": "How the Metis ruled the world"
+				},
+				"slug": {
+					"type": "string",
+					"example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
+				},
+				"description": {
+					"type": "string",
+					"example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
+				},
+				"body": {
+					"type": "string",
+					"example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
+				},
+				"image": {
+					"type": "string",
+					"example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
+				}
+			}
+		},
+		"ArticleResponseBody": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string",
+					"example": "How the Metis ruled the world"
+				},
+				"slug": {
+					"type": "string",
+					"example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
+				},
+				"description": {
+					"type": "string",
+					"example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
+				},
+				"body": {
+					"type": "string",
+					"example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
+				},
+				"image": {
+					"type": "string",
+					"example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
+				},
+				"createdAt": {
+					"type": "string",
+					"format": "datetime",
+					"example": "2018-09-05T00:00:00.000Z"
+				},
+				"updatedAt": {
+					"type": "string",
+					"format": "datetime",
+					"example": "2018-09-05T00:00:00.000Z"
+				}
+			}
+		},
+		"ArticlesResponseBody": {
+			"type": "object",
+			"properties": {
+				"status": {
+					"type": "string",
+					"example": "success"
+				},
+				"data": {
+					"type": "object",
+					"properties": {
+						"articles": {
+							"type": "array",
+							"items": {
+								"$ref" : "#/definitions/ArticleResponseBody"
+							}
+						},
+						"currentPage": {
+							"type": "integer",
+							"example": 1
+						}
+					}
+				}
+			}
+			},
+		"Update": {
+			"type": "object",
+			"properties": {
+				"firstname": {
+					"type": "string",
+					"example": "joe"
+				},
+				"lastname": {
+					"type": "string",
+					"example": "easy"
+				},
+				"username": {
+					"type": "string",
+					"example": "metis"
+				},
+				"email": {
+					"type": "string",
+					"example": "metis@gmail.com"
+				},
+				"password": {
+					"type": "string",
+					"example": "password"
+				},
+				"bio": {
+					"type": "string",
+					"example": "Here is a brief information about me"
+				},
+				"interest": {
+					"type": "array",
+					"example": ["gaming", "entreprenuership"]
+				}
+			},
+			"json": {
+				"name": "User"
+			}
+		},
+		"userId": {
+			"type": "number",
+			"example": 1
+		}
+  },
+  "ArticleRequestBody": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "example": "How the Metis ruled the world"
       },
-      "json": {
-        "name": "User"
+      "slug": {
+        "type": "string",
+        "example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
+      },
+      "description": {
+        "type": "string",
+        "example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
+      },
+      "body": {
+        "type": "string",
+        "example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
+      },
+      "image": {
+        "type": "string",
+        "example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
       }
-    },
-    "userId": {
-      "type": "number",
-      "example": 1
-    },
-    "roles": {
-      "type": "object",
-      "properties": {
-        "role": {
-          "type": "string",
-          "example": "reader"
-        },
-        "permissions": {
-          "type": "array",
-          "example": [
-            "read",
-            "write"
-          ]
-        }
+    }
+  },
+  "ArticleResponseBody": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "example": "How the Metis ruled the world"
+      },
+      "slug": {
+        "type": "string",
+        "example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
+      },
+      "description": {
+        "type": "string",
+        "example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
+      },
+      "body": {
+        "type": "string",
+        "example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
+      },
+      "image": {
+        "type": "string",
+        "example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "datetime",
+        "example": "2018-09-05T00:00:00.000Z"
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "datetime",
+        "example": "2018-09-05T00:00:00.000Z"
       }
-    },
-    "roles1": {
-      "type": "object",
-      "properties": {
-        "role": {
-          "type": "string",
-          "example": "reader"
-        },
-        "addPermissions": {
-          "type": "array",
-          "example": [
-            "read",
-            "write"
-          ]
-        },
-        "removePermissions": {
-          "type": "array",
-          "example": [
-            "view users",
-            "like"
-          ]
-        }
-      }
-    },
-    "authors-of-the-week": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "string",
-          "example": "success"
-        },
-        "data": {
-          "type": "object",
-          "properties": {
-            "authors": {
-              "type": "array",
-              "items": {
-                "author": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer",
-                      "example": "1"
-                    },
-                    "likesCount": {
-                      "type": "integer",
-                      "example": "2343"
-                    },
-                    "userId": {
-                      "type": "integer",
-                      "example": "2"
-                    },
-                    "firstname": {
-                      "type": "string",
-                      "example": "John"
-                    },
-                    "lastname": {
-                      "type": "string",
-                      "example": "Doe"
-                    },
-                    "image": {
-                      "type": "string",
-                      "example": "https://someimgurl.com"
-                    }
-                  }
-                }
-              }
+    }
+  },
+  "ArticlesResponseBody": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "example": "success"
+      },
+      "data": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref" : "#/definitions/ArticleResponseBody"
             }
+          },
+          "currentPage": {
+            "type": "integer",
+            "example": 1
           }
         }
       }

--- a/swagger.json
+++ b/swagger.json
@@ -1405,7 +1405,38 @@
           }
         }
       }
-    }
+    },
+    "/api/v1/articles/bookmarks": {
+			"parameters": [{
+				"name": "token",
+				"in": "headers",
+				"required": true,
+				"description": "Authorization header",
+				"type": "string"
+			}],
+			"post": {
+				"summary": "Allows users to bookmark an article",
+				"description": "",
+				"schema": {
+					"$ref": "#/definitions/Bookmarks"
+				},
+				"responses": {
+					"200": {
+						"description": "Add articles to bookmark"
+					}
+				}
+			},
+			"get": {
+				"summary": "Allows users view the list of all articles that have been bookmarked",
+				"description": "Allows and authenticated user to view the list of all articles he has bookmarked",
+				"responses": {
+					"200": {
+						"description": "Returns bookmarked all articles"
+					}
+				}
+			}
+	
+		}
   },
   "definitions": {
     "signin": {
@@ -1809,42 +1840,15 @@
 		"Update": {
 			"type": "object",
 			"properties": {
-				"firstname": {
+				"title": {
 					"type": "string",
-					"example": "joe"
+					"example": "The day I'll never forget"
 				},
-				"lastname": {
-					"type": "string",
-					"example": "easy"
-				},
-				"username": {
-					"type": "string",
-					"example": "metis"
-				},
-				"email": {
-					"type": "string",
-					"example": "metis@gmail.com"
-				},
-				"password": {
-					"type": "string",
-					"example": "password"
-				},
-				"bio": {
-					"type": "string",
-					"example": "Here is a brief information about me"
-				},
-				"interest": {
-					"type": "array",
-					"example": ["gaming", "entreprenuership"]
+				"id": {
+					"type": "number",
+					"example": 1
 				}
-			},
-			"json": {
-				"name": "User"
 			}
-		},
-		"userId": {
-			"type": "number",
-			"example": 1
 		}
   },
   "ArticleRequestBody": {


### PR DESCRIPTION
**What does this PR do?**
Implements a feature that allows users to: 
- bookmark an article
- view all their bookmarked articles

**Description of Task to be completed?**
- write the test for bookmarking articles
- write the test for getting all bookmarked articles
- write documentation for bookmarking an article
**How should this be manually tested?**
Clone the repository.
Check out the `ft-users-can-bookmark-article` branch.
Run `NPM INSTALL` on your local machine.
Run database migrations using `npm run migrate`.
Start the server using `NPM RUN START_DEV`.

**You can test the following endpoints using postman**
POST `localhost:8000/api/v1/articles/bookmarks` to bookmark an article
GET `localhost:8000/api/v1/articles/bookmarks` to view all bookmarked articles
HEADERS
- authorization -> paste your token there

REQUIRED FIELDS
POST
-    title: `string`
-   id(article ID): `number`


**What are the relevant pivotal tracker stories?**
#159987417