### PR TITLE
#159987412 Pagination support for articles

### DIFF
--- a/server/controllers/articleController.js
+++ b/server/controllers/articleController.js
@@ -156,6 +156,34 @@ const articlesController = {
         analyseRatings(req, res);
       }
     });
+  },
+  /**
+  * @desc validates article input fields
+  * @param  {object} req Http Request object
+  * @param  {object} res Http Response object
+  * @returns {object} httpResponse object
+  */
+  getArticles: (req, res) => {
+    const queryParams = req.paginationQueryParams;
+    // CALCULATE OFFSET
+    const offset = ((queryParams.page - 1) * queryParams.limit);
+    Articles.findAndCountAll({
+      offset,
+      limit: queryParams.limit
+    }).then((result) => {
+      const totalPages = Math.ceil(result.count / queryParams.limit);
+
+      return res.status(200).jsend.success({
+        message: 'Operation Successful',
+        articles: result.rows,
+        metadata: {
+          totalArticles: result.count,
+          currentPage: queryParams.page,
+          limit: queryParams.limit,
+          totalPages
+        }
+      });
+    });
   }
 };
 

--- a/server/middleware/paginationParamsValidations.js
+++ b/server/middleware/paginationParamsValidations.js
@@ -1,0 +1,19 @@
+
+
+const paginationParamsValidations = (req, res, next) => {
+  // VALIDATE PAGE NUMBER
+  let page = parseInt(req.query.page, 10);
+  if (!Number.isInteger(page) || page < 1) {
+    page = 1;
+  }
+  // VALIDATE LIMIT NUMBER
+  let limit = parseInt(req.query.limit, 10);
+  if (!Number.isInteger(limit) || limit < 1) {
+    limit = 10;
+  }
+
+  req.paginationQueryParams = { page, limit };
+  next();
+};
+
+export default paginationParamsValidations;

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -10,12 +10,14 @@ import reportValidation from '../middleware/reportValidation';
 import usersValidations from '../middleware/usersValidations';
 import checkParams from '../middleware/checkParams';
 import { multerUploads } from '../config/multer/multerConfig';
+import paginationParamsValidations from '../middleware/paginationParamsValidations';
 
 const {
   reportArticle,
   rateArticle,
   create,
-  like
+  like,
+  getArticles
 } = articleController;
 const { addComment } = commentController;
 const { validateArticle, validateComments } = inputValidator;
@@ -35,6 +37,7 @@ const {
 const articleRoutes = express.Router();
 
 // POST ARTICLE ROUTE
+articleRoutes.get('/', auth, paginationParamsValidations, getArticles);
 articleRoutes.post('/:articleId', auth, validArticleId, validateComments, addComment);
 articleRoutes.post(
   '/:articleId/comments/like',

--- a/server/seeders/20180909082852-demo-article.js
+++ b/server/seeders/20180909082852-demo-article.js
@@ -1,6 +1,6 @@
 module.exports = {
   up: queryInterface => queryInterface.bulkInsert('Articles', [{
-    slug: 'just-a-sample-article',
+    slug: 'just-a-sample-article1',
     title: 'Just a Sample Article',
     description: 'This is a seed article used for testing purposes',
     body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
@@ -14,7 +14,7 @@ module.exports = {
     updatedAt: '2018-09-09'
   },
   {
-    slug: 'just-a-sample-article',
+    slug: 'just-a-sample-article2',
     title: 'Another Sample Article',
     description: 'This is a seed article used for testing purposes',
     body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
@@ -28,7 +28,7 @@ module.exports = {
     updatedAt: '2018-09-09'
   },
   {
-    slug: 'just-a-sample-article',
+    slug: 'just-a-sample-article3',
     title: 'Some other Sample Article',
     description: 'This is a seed article used for testing purposes',
     body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
@@ -37,6 +37,132 @@ module.exports = {
 
     Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
     userId: 1,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article4',
+    title: 'Just a  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 4,
+    categoryId: 1,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article5',
+    title: 'Another  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 2,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article6',
+    title: 'Some other  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 1,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article7',
+    title: 'Some other  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 3,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article8',
+    title: 'Just a  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 4,
+    categoryId: 1,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article9',
+    title: 'Another  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 3,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article10',
+    title: 'Some other  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 4,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article11',
+    title: 'Another  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 3,
+    categoryId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    slug: 'just-a-sample-article12',
+    title: 'Some other  Article',
+    description: 'This is a seed article used for testing purposes',
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque dui eros, tristique nec mollis et, dapibus eu nisl. Phasellus ultricies semper lorem sit amet tempor. Donec sed eros quis ante lobortis dapibus. Vestibulum eu sem lacus. Cras sagittis non velit at molestie. Aliquam volutpat rutrum neque vulputate accumsan. Donec eu purus nisi. Nam varius sodales quam, in aliquet tortor rutrum sed. Nullam suscipit, magna at rutrum porta, risus justo varius eros, et lacinia justo libero id quam. Curabitur fringilla porttitor ultrices. Ut a luctus risus. Etiam eget bibendum justo. Curabitur dolor nisi, porttitor eu scelerisque ac, consequat et odio. Duis dui enim, dignissim rutrum vestibulum et, lacinia vitae ex. Proin ut sem euismod, vestibulum sapien a, porta nibh.
+
+    Etiam tellus leo, tincidunt ac leo quis, placerat fermentum ligula. Praesent tellus enim, ultrices in justo ut, rhoncus auctor justo. Donec nec tellus lectus. Vivamus sapien lorem, maximus quis ornare et, sollicitudin sit amet sapien. Aenean euismod a justo quis bibendum. Etiam feugiat massa ut metus hendrerit commodo. Fusce quis sodales diam. Pellentesque mattis mauris ac ornare vestibulum.
+
+    Fusce hendrerit, nisi non pretium accumsan, velit ipsum tempus turpis, in ullamcorper nisi tortor sit amet nibh. Praesent id tortor erat. Praesent odio massa, congue eu commodo eu, fermentum eget nibh. Nulla eu tellus lectus. Nam sed pellentesque metus. Vestibulum odio nisl, efficitur blandit ipsum a, imperdiet vestibulum tortor. Nullam commodo nisi elit, eleifend pellentesque sem sagittis ut. Sed sit amet convallis lectus. Suspendisse a massa vitae sem iaculis finibus ut vel mauris. Praesent et viverra ex, non molestie lorem.`,
+    userId: 4,
     categoryId: 2,
     createdAt: '2018-09-09',
     updatedAt: '2018-09-09'

--- a/swagger.json
+++ b/swagger.json
@@ -745,6 +745,115 @@
           }
         }
       }
+    },
+    "/api/v1/articles": {
+      "post": {
+        "tags": [ "Articles" ],
+        "summary": "Allows user to create and publish articles",
+        "description": "This gives user the ability to create and publish articles with support for images",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "title",
+            "type": "string",
+            "description": "Article's title",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "name": "description",
+            "type": "string",
+            "description": "A description of an article",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "name": "body",
+            "type": "string",
+            "description": "Article's body",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "name": "image",
+            "type": "file",
+            "description": "An image reflecting the content of an article",
+            "required": false
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "description": "authentication access token for users to access this endpoint",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Article published successfully"
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "400": {
+            "description": "Invalid User Input"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "get": {
+        "tags": [ "Articles" ],
+        "summary": "Pagination support for getting articles",
+        "description": "Allows users to specify the number of articles they want to view within a specified limit",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "description": "authentication access token for users to access this endpoint",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "this indicates the number of articles to be return per page",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "this indicates the current page number for viewing articles",
+            "required": false,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation successfully"
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -1048,6 +1157,90 @@
               "type": "string",
               "example": "There are no cases"
             }
+          }
+        }
+      }
+    }
+  },
+  "ArticleRequestBody": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "example": "How the Metis ruled the world"
+      },
+      "slug": {
+        "type": "string",
+        "example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
+      },
+      "description": {
+        "type": "string",
+        "example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
+      },
+      "body": {
+        "type": "string",
+        "example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
+      },
+      "image": {
+        "type": "string",
+        "example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
+      }
+    }
+  },
+  "ArticleResponseBody": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "example": "How the Metis ruled the world"
+      },
+      "slug": {
+        "type": "string",
+        "example": "How-the-Metis-ruled-the-world-89043hjk54b325bj42j234093hh3e"
+      },
+      "description": {
+        "type": "string",
+        "example": "How the metis ruled the world is an article that will open your mind and show you the might power of team work. Enjoy"
+      },
+      "body": {
+        "type": "string",
+        "example": "Quisque accumsan ngue sed, scelerisque ut turpis. Mauris ut ornare erat. Duis hendrerit massa urna, ut pretium ante porttitor eget. Sed quam urna, euismod vel massa at, tempor consequat leo. Quisque nec felis ac ante luctus tincidunt. Sed rutrum orci sit amet orci ultrices"
+      },
+      "image": {
+        "type": "string",
+        "example": "http://res.cloudinary.com/demo/image/upload/v1473596672/eneivicys42bq5f2jpn2.jpg"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "datetime",
+        "example": "2018-09-05T00:00:00.000Z"
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "datetime",
+        "example": "2018-09-05T00:00:00.000Z"
+      }
+    }
+  },
+  "ArticlesResponseBody": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "example": "success"
+      },
+      "data": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref" : "#/definitions/ArticleResponseBody"
+            }
+          },
+          "currentPage": {
+            "type": "integer",
+            "example": 1
           }
         }
       }

--- a/test/articles.spec.js
+++ b/test/articles.spec.js
@@ -144,6 +144,161 @@ describe('ARTICLE ENDPOINT TESTS', () => {
         });
     });
   });
+
+  describe('GET ARTICLES WITH PAGINATION', () => {
+    it('should return articles successfully for an authenticated user', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.be.greaterThan(0);
+          done();
+        });
+    });
+
+    it('should return articles successfully with current page = 1 when page number is undefined', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ page: undefined, limit: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.be.greaterThan(0);
+          res.body.data.metadata.currentPage.should.equal(1);
+          done();
+        });
+    });
+
+    it('should return articles successfully with current page = 1 when page number is not a number', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ page: 'kjhs3w', limit: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.be.greaterThan(0);
+          res.body.data.metadata.currentPage.should.equal(1);
+          done();
+        });
+    });
+
+    it('should return articles successfully with current page = 1, when page number is less than 1', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ page: -4, limit: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.be.greaterThan(0);
+          res.body.data.metadata.currentPage.should.equal(1);
+          done();
+        });
+    });
+
+    it('should return default 10 articles article successfully when limit is less than 1', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ limit: -2, page: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.equal(10);
+          done();
+        });
+    });
+
+    it('should return successfully with a default of 10 articles when limit is not a number', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ limit: '', page: [] })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.equal(10);
+          done();
+        });
+    });
+
+    it('should return 12 article successfully when limit equals 12', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ limit: 12, page: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.body.status.should.equal('success');
+          res.status.should.equal(200);
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles.length.should.equal(12);
+          done();
+        });
+    });
+
+    it('should fail when token is undefined', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ limit: 12, page: 1 })
+        .end((err, res) => {
+          res.status.should.equal(401);
+          res.body.status.should.equal('fail');
+          res.body.data.message.should.equal('No token provided');
+          done();
+        });
+    });
+
+    it('should return first item first', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ limit: 5, page: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.equal(200);
+          res.body.status.should.equal('success');
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.articles[0].id.should.equal(1);
+          done();
+        });
+    });
+
+    it('should return successfully with required metadata', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles')
+        .query({ limit: 5, page: 1 })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.equal(200);
+          res.body.status.should.equal('success');
+          res.body.data.articles.should.be.an('Array');
+          res.body.data.should.have.property('metadata');
+          res.body.data.metadata.should.have.property('limit');
+          res.body.data.metadata.should.have.property('currentPage');
+          res.body.data.metadata.should.have.property('totalPages');
+          done();
+        });
+    });
+  });
 });
 
 describe('Articles likes test', () => {

--- a/test/search.spec.js
+++ b/test/search.spec.js
@@ -24,7 +24,7 @@ describe('Search Functionality tests', () => {
         .get('/api/v1/articles/search?author=postm')
         .end((err, res) => {
           res.should.have.status(200);
-          res.body.data.searchResult.count.should.equal(4);
+          res.body.data.searchResult.count.should.equal(6);
           done();
         });
     });


### PR DESCRIPTION
**What does this PR do?**
Allow users to get the exact number of articles they want within specified limits per page

**Description of Task to be completed?**

- write tests for the endpoint
- write a validator middleware for `query parameters`
- write a code to calculate `pagination limit offset`


**How should this be manually tested?**

Clone the **repository**
Check out the `ft-pagination-support-for-articles-159987412` branch
Run `npm install` on your local machine
Run database migrations using `npm run migrate`
Start the server using `npm start`
Go to **GET** `localhost:8000/api/v1/articles` with postman
Note: Authentication token is required to access this route 

**What are the relevant pivotal tracker stories?**
#159987412