### PR TITLE
 #159987422 user can highlight and comment on an article

### DIFF
--- a/server/controllers/hightlightController.js
+++ b/server/controllers/hightlightController.js
@@ -1,0 +1,140 @@
+import helpers from '../helpers/helpers';
+import models from '../models';
+
+const { Highlights } = models;
+const { parsedId } = helpers;
+
+const highlightController = {
+  /**
+   * @method create
+   * @description Allows users to highlight an article
+   * @param {Object} req - The request object
+   * @param {Object} res -  The response object
+   * @return {Object} The result from hightlight the article
+   */
+  create: (req, res) => {
+    const { highlightedText, comment, color } = req.body;
+    const authorId = parsedId(req.params.authorId);
+    const articleId = parsedId(req.params.articleId);
+    Highlights.findOrCreate({
+      where: {
+        highlightedText,
+        userId: req.currentUser.id,
+        articleId,
+        comment,
+        color,
+        authorId
+      }
+    })
+      .spread((highlight, created) => (!(created) ? res.status(400).jsend.fail({ message: `You have already commented on ${highlightedText}` })
+        : res.status(201).jsend.success({
+          highlight,
+          message: 'Your comment has been saved'
+        })))
+      .catch(err => res.status(500).jsend.fail({
+        message: 'Something went wrong, please try again',
+        error: err.message
+      }));
+  },
+
+  /**
+   * @method fetchAll
+   * @description All an author to view all highlight on an article
+   * @param {Object} req - The request object
+   * @param {Object} res -  The response object
+   * @returns {Object} All highlights on the article
+   */
+  fetchAll: (req, res) => {
+    const authorId = req.currentUser.id;
+    const articleId = parsedId(req.params.articleId);
+    Highlights.findAll({
+      where: {
+        authorId,
+        articleId
+      }
+    }).then(highlights => res.status(200).jsend.success({
+      message: 'Highlighted text',
+      highlights
+    }))
+      .catch(err => res.status(500).jsend.fail({
+        message: 'Something went wrong, please try again',
+        error: err.message
+      }));
+  },
+
+  /**
+   * @method fetchReaderHighlight
+   * @description Allows logged in users to view their highlights on an article
+   * @param {Object} req - The request object
+   * @param {Object} res - The response object
+   * @returns {Object}  The highlights of the user
+   */
+  fetchReaderHighlight: (req, res) => {
+    const articleId = parsedId(req.params.articleId);
+    Highlights.findAll({
+      where: {
+        userId: req.currentUser.id,
+        articleId
+      }
+    }).then(highlights => res.status(200).jsend.success({
+      message: 'Highlighted text',
+      highlights
+    }))
+      .catch(err => res.status(500).jsend.fail({
+        message: 'Something went wrong, please try again',
+        error: err.message
+      }));
+  },
+  /**
+   * @method update
+   * @description Allows users to update the comment they've created
+   * @param {Object} req - The request object
+   * @param {Object} res - The response object
+   * @returns {Object}  The update highlight of the user
+   */
+  update: (req, res) => {
+    const { comment, color } = req.body;
+    const articleId = parsedId(req.params.articleId);
+    Highlights.update({ comment, color }, {
+      where: {
+        userId: req.currentUser.id,
+        articleId
+      },
+    }).then((highlight) => {
+      if (highlight) {
+        return res.status(200).jsend.success({
+          message: 'Your highlight has been updated successfully',
+          highlight
+        });
+      }
+    }).catch(err => res.status(500).jsend.fail({
+      message: 'Something went wrong, please try again',
+      error: err.message
+    }));
+  },
+
+  /**
+   * @method Delete
+   * @description Allows users to remove an highlight they've created
+   * @param {Object} req - The request object
+   * @param {Object} res - The response object
+   * @returns {Object}  deleted success message
+   */
+  delete: (req, res) => {
+    const authorId = parsedId(req.params.authorId);
+    const articleId = parsedId(req.params.articleId);
+    Highlights.destroy({
+      where: {
+        userId: req.currentUser.id || authorId,
+        articleId
+      }
+    }).then(() => res.status(200).jsend.success({
+      message: 'Your highlight have been deleted'
+    })).catch(err => res.status(500).jsend.fail({
+      message: 'Something went wrong, please try again',
+      error: err.message
+    }));
+  }
+};
+
+export default highlightController;

--- a/server/helpers/helpers.js
+++ b/server/helpers/helpers.js
@@ -164,7 +164,8 @@ const helpers = {
     const eleInt = eleStr.map(element => Number(element));
 
     return eleInt;
-  }
+  },
+  parsedId: id => ((!(/^\d+$/.test(id))) ? NaN : parseInt(id, 10)),
 };
 
 export default helpers;

--- a/server/helpers/highlightHelpers.js
+++ b/server/helpers/highlightHelpers.js
@@ -1,0 +1,42 @@
+import helpers from './helpers';
+
+
+const { parsedId } = helpers;
+
+const highlightValidation = {
+  authorId: (req, res, next) => {
+    const authorId = parsedId(req.params.authorId);
+    if (
+      !(Number.isInteger(authorId))
+    ) {
+      return res.status(400).jsend.fail({
+        message: 'Your request is not valid'
+      });
+    }
+    return next();
+  },
+  articleId: (req, res, next) => {
+    const articleId = parsedId(req.params.articleId);
+    if (
+      !(Number.isInteger(articleId))
+    ) {
+      return res.status(400).jsend.fail({
+        message: 'Your request is not valid'
+      });
+    }
+    return next();
+  },
+  comment: (req, res, next) => {
+    const { comment } = req.body;
+    if (
+      !comment || comment.trim().length < 1
+    ) {
+      return res.status(400).jsend.fail({
+        message: 'Comment is required'
+      });
+    }
+    return next();
+  }
+};
+
+export default highlightValidation;

--- a/server/migrations/20180919080241-create-highlights.js
+++ b/server/migrations/20180919080241-create-highlights.js
@@ -1,0 +1,55 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Highlights', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    highlightedText: {
+      type: Sequelize.STRING
+    },
+    color: {
+      type: Sequelize.STRING
+    },
+    comment: {
+      type: Sequelize.STRING
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      }
+    },
+    authorId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'authorId'
+      }
+    },
+    articleId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Articles',
+        key: 'id',
+        as: 'articleId'
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Highlights')
+};

--- a/server/models/highlights.js
+++ b/server/models/highlights.js
@@ -1,0 +1,33 @@
+const hightlights = (sequelize, DataTypes) => {
+  const Highlights = sequelize.define('Highlights', {
+    highlightedText: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    comment: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    color: {
+      type: DataTypes.STRING
+    }
+  });
+  Highlights.associate = (models) => {
+    Highlights.belongsTo(models.Users, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE'
+    });
+    Highlights.belongsTo(models.Users, {
+      foreignKey: 'authorId',
+      onDelete: 'CASCADE'
+    });
+    Highlights.belongsTo(models.Articles, {
+      foreignKey: 'articleId',
+      as: 'articles',
+      onDelete: 'CASCADE'
+    });
+  };
+  return Highlights;
+};
+
+export default hightlights;

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -11,6 +11,8 @@ import usersValidations from '../middleware/usersValidations';
 import checkParams from '../middleware/checkParams';
 import { multerUploads } from '../config/multer/multerConfig';
 import paginationParamsValidations from '../middleware/paginationParamsValidations';
+import highlightController from '../controllers/hightlightController';
+import highlightValidation from '../helpers/highlightHelpers';
 
 const {
   reportArticle,
@@ -33,6 +35,11 @@ const {
   validateViolation,
   validateRequestObject,
 } = reportValidation;
+const {
+  authorId,
+  articleId,
+  comment
+} = highlightValidation;
 
 const articleRoutes = express.Router();
 
@@ -65,4 +72,21 @@ articleRoutes.post(
   reportArticle
 );
 articleRoutes.get('/search', searchController);
+
+// HIGHLIGHT ROUTES
+// create highlights
+articleRoutes.post('/highlights/:articleId/:authorId', auth, articleId, authorId, comment, highlightController.create);
+
+// fetch all reader's highlight
+articleRoutes.get('/highlights/:articleId/:authorId', auth, articleId, authorId, highlightController.fetchReaderHighlight);
+
+// fetch all highlights for author
+articleRoutes.get('/highlights/:articleId/:authorId/all', auth, articleId, authorId, highlightController.fetchReaderHighlight);
+
+// update highlight route
+articleRoutes.put('/highlights/:articleId/:authorId', auth, articleId, authorId, comment, highlightController.update);
+
+// delete an highlight
+articleRoutes.delete('/highlights/:articleId/:authorId', auth, articleId, authorId, highlightController.delete);
+
 export default articleRoutes;

--- a/swagger.json
+++ b/swagger.json
@@ -876,6 +876,132 @@
             "required": false,
             "type": "number"
           }
+        ]
+      }
+    },
+		"/api/v1/articles/highlights/:articleId/:authorId": {
+			"post": {
+        "tags": [ "Highlight" ],
+        "summary": "Route for authenticated users to highlight and comment on a section of an article",
+        "description": "Returns the user and the user's comment on highlighted text",
+        "parameters": [
+          {
+            "in": "articleId",
+            "name": "articleId",
+            "description": "This params takes in the articleId",
+            "required": true
+					},
+					{
+            "in": "authorId",
+            "name": "articleId",
+            "description": "This params takes in the authorId",
+            "required": true
+					},
+					{
+            "in": "header",
+            "name": "authorization",
+            "description": "user token",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Highlight comment was posted successfully"
+          },
+          "500": {
+            "description": "something went wrong on the sever side"
+          }
+        }
+			},
+			"get": {
+        "tags": [ "Highlight" ],
+        "summary": "Route for authenticated users to view their comments on articles they've highlighted",
+        "description": "Returns the user's comments on highlighted the article",
+        "parameters": [
+          {
+            "in": "articleId",
+            "name": "articleId",
+            "description": "This params takes in the articleId",
+            "required": true
+					},
+					{
+            "in": "authorId",
+            "name": "articleId",
+            "description": "This params takes in the authorId",
+            "required": true
+					},
+					{
+            "in": "header",
+            "name": "authorization",
+            "description": "user token",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Highlight comment was posted successfully"
+          },
+          "500": {
+            "description": "something went wrong on the sever side"
+          }
+        }
+			},
+			"put": {
+        "tags": [ "Highlight" ],
+        "summary": "Route for authenticated users to update their comments on articles they've highlighted",
+        "description": "Returns the user's comments on highlighted the article",
+        "parameters": [
+          {
+            "in": "articleId",
+            "name": "articleId",
+            "description": "This params takes in the articleId",
+            "required": true
+					},
+					{
+            "in": "authorId",
+            "name": "articleId",
+            "description": "This params takes in the authorId",
+            "required": true
+					},
+					{
+            "in": "header",
+            "name": "authorization",
+            "description": "user token",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Highlight comment was posted successfully"
+          },
+          "500": {
+            "description": "something went wrong on the sever side"
+          }
+        }
+			},
+			"delete": {
+        "tags": [ "Highlight" ],
+        "summary": "Route for authenticated readers and author of the article to delete comments on articles they've highlighted",
+        "description": "Returns the user's comments on highlighted the article",
+        "parameters": [
+          {
+            "in": "articleId",
+            "name": "articleId",
+            "description": "This params takes in the articleId",
+            "required": true
+					},
+					{
+            "in": "authorId",
+            "name": "articleId",
+            "description": "This params takes in the authorId",
+            "required": true
+					},
+					{
+            "in": "header",
+            "name": "authorization",
+            "description": "user token",
+            "required": true
+          }
         ],
         "responses": {
           "200": {
@@ -888,6 +1014,12 @@
             "description": "Internal server error"
           }
         }
+      },
+      "200": {
+        "description": "Highlight comment was posted successfully"
+      },
+      "500": {
+        "description": "something went wrong on the sever side"
       }
     }
   },

--- a/test/highlights.spec.js
+++ b/test/highlights.spec.js
@@ -1,0 +1,160 @@
+// globals assert, expect, describe
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../server/app';
+import generateToken from '../server/helpers/generateToken';
+
+chai.use(chaiHttp);
+const { expect, should } = chai;
+should();
+
+const verifiedToken = generateToken(7200, { id: 1, isVerified: true });
+describe('HIGHTLIGHT AN ARTICLE', () => {
+  it('Should create an highlight', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/articles/highlights/1/1')
+      .set('Authorization', verifiedToken)
+      .send({
+        comment: 'How I Learnt React in Andela',
+        color: '#333333',
+        highlightedText: 'This how we learn react'
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Your comment has been saved');
+        done();
+      });
+  });
+  it('Should not highlight a portion twice', (done) => {
+    const highlightedText = 'This how we learn react';
+    chai
+      .request(app)
+      .post('/api/v1/articles/highlights/1/1')
+      .set('Authorization', verifiedToken)
+      .send({
+        comment: 'How I Learnt React in Andela',
+        color: '#333333',
+        highlightedText
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal(`You have already commented on ${highlightedText}`);
+        done();
+      });
+  });
+  it('Should not highlight an article when articleId is empty or not a number', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/articles/highlights/hda/1')
+      .set('Authorization', verifiedToken)
+      .send({
+        comment: 'How I Learnt React in Andela',
+        color: '#333333',
+        highlightedText: 'This how we learn react'
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Your request is not valid');
+        done();
+      });
+  });
+  it('Should not highlight an article when authorId is empty or not a number', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/articles/highlights/1/dbajd')
+      .set('Authorization', verifiedToken)
+      .send({
+        comment: 'How I Learnt React in Andela',
+        color: '#333333',
+        highlightedText: 'This how we learn react'
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Your request is not valid');
+        done();
+      });
+  });
+  it('Should not highlight an article when there are no comments', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/articles/highlights/1/dbajd')
+      .set('Authorization', verifiedToken)
+      .send({
+        comment: 'How I Learnt React in Andela',
+        color: '#333333',
+        highlightedText: 'This how we learn react'
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Your request is not valid');
+        done();
+      });
+  });
+});
+
+describe('FETCH ALL Higlights', () => {
+  it('Should fetch all the users highlight on an article', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/highlights/1/1')
+      .set('Authorization', verifiedToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Highlighted text');
+        done();
+      });
+  });
+  it('Should fetch all the highlights on an article', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/highlights/1/1/all')
+      .set('Authorization', verifiedToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Highlighted text');
+        done();
+      });
+  });
+});
+describe('UPDATE  Higlights', () => {
+  it('Should update an highlight', (done) => {
+    chai
+      .request(app)
+      .put('/api/v1/articles/highlights/1/1')
+      .set('Authorization', verifiedToken)
+      .send({
+        comment: 'How I Learnt React in Andela',
+        color: '#333',
+        highlightedText: 'noted',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Your highlight has been updated successfully');
+        done();
+      });
+  });
+});
+
+describe('DELETE  Higlights', () => {
+  it('Should delete an highlight', (done) => {
+    chai
+      .request(app)
+      .delete('/api/v1/articles/highlights/1/1')
+      .set('Authorization', verifiedToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.message).to.equal('Your highlight have been deleted');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
Allows users to highlight and comment on an article
 - authors can view all highlights and comment on their article
- users can view their highlight on an article - users can comment on a highlighted text
- users can edit/update comment on a highlighted text
- authors can delete highlight on their article
- users can delete their comments on a highlighted text

**Description of Task to be completed?**
- write the test for highlighting an article
- write the test for getting all user's highlight on an article
- write the test for the endpoint that allows authors to get all highlights for their article
- write the test that allows users and authors to delete a highlight.
- write the test that allows users to update their comments on the highlight.
- write documentation for the above features
**How should this be manually tested?**
Clone the repository.
Check out the `ft-user-can-hightlight-and-comment-#159987422` branch.
Run `NPM INSTALL` on your local machine.
Run database migrations using `npm run migrate`.
Start the server using `NPM RUN START_DEV`.

**You can test the following endpoints using postman**
POST `localhost:8000/api/v1//highlights/:articleId/:authorId` to create an hight
GET `localhost:8000/api/v1//highlights/:articleId/:authorId` to get a user's highlight
GET `localhost:8000/api/v1//highlights/:articleId/:authorId/all` to get all highlight for an author
PUT `localhost:8000/api/v1//highlights/:articleId/:authorId` to edit a user's highlight
DELETE `localhost:8000/api/v1//highlights/:articleId/:authorId` allows users and authors to delete a comment
HEADERS
- authorization -> paste your token there

REQUIRED FIELDS
POST
-    comment: `string`
-   color: `string`


**What are the relevant pivotal tracker stories?**
 #159987422