### PR TITLE
#159987420 user should be able to see their reading statistic 

### DIFF
--- a/server/controllers/articleController.js
+++ b/server/controllers/articleController.js
@@ -6,6 +6,7 @@ import models from '../models';
 import { dataUri } from '../config/multer/multerConfig';
 import imageUpload from '../helpers/imageUpload';
 import tagManager from '../helpers/tagManager';
+import saveStatsData from '../helpers/saveStatsData';
 
 const {
   Cases,
@@ -247,6 +248,9 @@ const articlesController = {
           message: 'Article not found'
         });
       }
+
+      // SAVE STATISTICS DATA
+      saveStatsData(req, article.id);
 
       const likes = article.articleLikes.filter(like => like.like === true).length;
       const dislikes = article.articleLikes.filter(like => like.dislike === true).length;

--- a/server/helpers/saveStatsData.js
+++ b/server/helpers/saveStatsData.js
@@ -1,0 +1,20 @@
+import models from '../models/index';
+
+const { ReadingStatistics } = models;
+
+const saveStats = (req, articleId) => {
+  const userId = req.currentUser.id;
+
+  ReadingStatistics.findOrCreate({
+    where: {
+      articleId,
+      userId
+    },
+    defaults: {
+      articleId,
+      userId
+    }
+  }).spread(() => true);
+};
+
+export default saveStats;

--- a/server/middleware/statsParamsValidations.js
+++ b/server/middleware/statsParamsValidations.js
@@ -1,0 +1,44 @@
+import { Op } from 'sequelize';
+
+
+const statsParamsValidations = (req, res, next) => {
+  const { q } = req.query;
+  const week = 7 * 24 * 60 * 60 * 1000;
+  const month = 30 * 24 * 60 * 60 * 1000;
+
+
+  switch (q) {
+    case 'week':
+      req.statsQuery = {
+        userId: req.currentUser.id,
+        createdAt: { [Op.between]: [new Date(new Date() - week), new Date()] },
+      };
+      next();
+      break;
+    case 'month':
+      req.statsQuery = {
+        userId: req.currentUser.id,
+        createdAt: { [Op.between]: [new Date(new Date() - month), new Date()] },
+      };
+      next();
+      break;
+    case 'all':
+      req.statsQuery = {
+        userId: req.currentUser.id
+      };
+      next();
+      break;
+    case undefined:
+      req.statsQuery = {
+        userId: req.currentUser.id
+      };
+      next();
+      break;
+    default:
+      return res.status('400').jsend.fail({
+        message: 'Invalid Query value. Expects q to equal (week|month|all)'
+      });
+  }
+};
+
+export default statsParamsValidations;

--- a/server/migrations/20180921093002-create-readingstatistics.js
+++ b/server/migrations/20180921093002-create-readingstatistics.js
@@ -1,0 +1,37 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('ReadingStatistics', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      }
+    },
+    articleId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Articles',
+        key: 'id',
+        as: 'articleId'
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }, { freezeName: true }),
+  down: queryInterface => queryInterface.dropTable('ReadingStatistics')
+};

--- a/server/models/articles.js
+++ b/server/models/articles.js
@@ -31,6 +31,10 @@ const articles = (sequelize, DataTypes) => {
       onDelete: 'CASCADE'
     });
 
+    Articles.hasMany(models.ReadingStatistics, {
+      foreignKey: 'articleId'
+    });
+
     Articles.belongsTo(models.Categories, {
       foreignKey: 'categoryId',
       as: 'category'

--- a/server/models/readingstatistics.js
+++ b/server/models/readingstatistics.js
@@ -1,0 +1,39 @@
+
+const readingStatistics = (sequelize, DataTypes) => {
+  const ReadingStatistics = sequelize.define('ReadingStatistics', {
+    userId: {
+      type: DataTypes.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      }
+    },
+    articleId: {
+      type: DataTypes.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Articles',
+        key: 'id',
+        as: 'articleId'
+      }
+    },
+  });
+
+  ReadingStatistics.associate = (models) => {
+    // associations can be defined here
+    ReadingStatistics.belongsTo(models.Users, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE'
+    });
+
+    ReadingStatistics.belongsTo(models.Articles, {
+      foreignKey: 'articleId',
+      onDelete: 'CASCADE'
+    });
+  };
+  return ReadingStatistics;
+};
+
+export default readingStatistics;

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -81,6 +81,10 @@ const users = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       as: 'articleLikes'
     });
+    Users.hasMany(models.ReadingStatistics, {
+      foreignKey: 'userId',
+      as: 'readingStats'
+    });
   };
   Users.beforeCreate((user) => {
     user.password = user.password ? bcrypt.hashSync(user.password, 8) : null;

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -17,7 +17,8 @@ const {
   rateArticle,
   create,
   like,
-  getArticles
+  getArticles,
+  getSingleArticle
 } = articleController;
 const { addComment } = commentController;
 const { validateArticle, validateComments } = inputValidator;
@@ -35,10 +36,13 @@ const {
 } = reportValidation;
 
 const articleRoutes = express.Router();
+articleRoutes.get('/', auth, paginationParamsValidations, getArticles);
+articleRoutes.get('/search', searchController);
 
 // POST ARTICLE ROUTE
-articleRoutes.get('/', auth, paginationParamsValidations, getArticles);
 articleRoutes.post('/:articleId', auth, validArticleId, validateComments, addComment);
+articleRoutes.get('/:articleId', auth, checkParams.id, getSingleArticle);
+
 articleRoutes.post(
   '/:articleId/comments/like',
   auth,
@@ -64,5 +68,5 @@ articleRoutes.post(
   validArticleId,
   reportArticle
 );
-articleRoutes.get('/search', searchController);
+
 export default articleRoutes;

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import userController from '../controllers/userController';
 import auth from '../middleware/auth';
+import userController from '../controllers/userController';
 import usersValidations from '../middleware/usersValidations';
 
 const { validateSignUp, validateLogin, validateNewPassword } = usersValidations;
@@ -16,5 +16,6 @@ userRoutes.delete('/:userId/unfollow', auth, userController.unfollow);
 userRoutes.get('/followings', auth, userController.following);
 userRoutes.post('/auth/reset-password', userController.resetPassword);
 userRoutes.put('/auth/reset-password/:token', auth, validateNewPassword, userController.reset);
+userRoutes.get('/statistics', auth, userController.getReadingStats);
 
 export default userRoutes;

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import auth from '../middleware/auth';
 import userController from '../controllers/userController';
 import usersValidations from '../middleware/usersValidations';
+import statsParamsValidations from '../middleware/statsParamsValidations';
 
 const { validateSignUp, validateLogin, validateNewPassword } = usersValidations;
 
@@ -16,6 +17,6 @@ userRoutes.delete('/:userId/unfollow', auth, userController.unfollow);
 userRoutes.get('/followings', auth, userController.following);
 userRoutes.post('/auth/reset-password', userController.resetPassword);
 userRoutes.put('/auth/reset-password/:token', auth, validateNewPassword, userController.reset);
-userRoutes.get('/statistics', auth, userController.getReadingStats);
+userRoutes.get('/me/statistics', auth, statsParamsValidations, userController.getReadingStats);
 
 export default userRoutes;

--- a/server/seeders/20180924172319-statsData.js
+++ b/server/seeders/20180924172319-statsData.js
@@ -1,0 +1,48 @@
+const now = new Date();
+
+module.exports = {
+  up: queryInterface => queryInterface.bulkInsert('ReadingStatistics', [{
+    userId: 1,
+    articleId: 2,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 1)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 1))
+  },
+  {
+    userId: 1,
+    articleId: 4,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 2)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 2))
+  },
+  {
+    userId: 1,
+    articleId: 5,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 6)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 6))
+  },
+  {
+    userId: 1,
+    articleId: 3,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 10)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 10))
+  },
+  {
+    userId: 1,
+    articleId: 1,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 28)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 28))
+  },
+  {
+    userId: 1,
+    articleId: 6,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 52)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 52))
+  },
+  {
+    userId: 3,
+    articleId: 4,
+    createdAt: new Date(now - (1000 * 60 * 60 * 24 * 68)),
+    updatedAt: new Date(now - (1000 * 60 * 60 * 24 * 68))
+  }]),
+
+  down: queryInterface => queryInterface.bulkDelete('ReadingStatistics')
+};

--- a/test/articles.spec.js
+++ b/test/articles.spec.js
@@ -389,3 +389,35 @@ describe('Articles likes test', () => {
       });
   });
 });
+
+describe('GET SINGLE ARTICLE TEST', () => {
+  it('should fail when article is not found', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/1008790')
+      .set('authorization', hashedToken)
+      .send()
+      .end((err, res) => {
+        expect(res.body.status).to.equal('fail');
+        expect(res.status).to.equal(404);
+        expect(res.body.data.message).to.equal('Article not found');
+        done();
+      });
+  });
+
+  it('should return successfully when article is found', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/2')
+      .set('authorization', hashedToken)
+      .end((err, res) => {
+        res.status.should.equal(200);
+        res.body.status.should.equal('success');
+        res.body.data.should.have.property('articleData');
+        res.body.data.should.have.property('metadata');
+        res.body.data.should.have.property('message');
+        res.body.data.articleData.should.have.property('body');
+        done();
+      });
+  });
+});

--- a/test/statistics.spec.js
+++ b/test/statistics.spec.js
@@ -1,0 +1,103 @@
+// globals assert, expect, describe
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../server/app';
+
+chai.use(chaiHttp);
+const { expect, should } = chai;
+should();
+
+let hashedToken;
+
+describe('ARTICLE ENDPOINT TESTS', () => {
+  // REGISTERS A NEW USER TO AVOID FOREIGN KEY ERROR
+  before('Register a new user', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/users/auth/login')
+      .send({
+        email: 'postman@gmail.com',
+        password: 'Password'
+      })
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        hashedToken = res.body.data.token;
+        done();
+      });
+  });
+
+  describe('USER READING STATISTICS ENDPOINT TESTS', () => {
+    it('should fail when query string is defined but neither of these (week,month,all)', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/users/me/statistics')
+        .query({ q: 'tuesdaylastweek' })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.eq(400);
+          res.body.status.should.eq('fail');
+          res.body.data.message.should.eq('Invalid Query value. Expects q to equal (week|month|all)');
+          done();
+        });
+    });
+
+    it('should return all statistics data successfully when query string is not defined', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/users/me/statistics')
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.eq(200);
+          res.body.status.should.eq('success');
+          res.body.data.message.should.eq('Operation Successful');
+          res.body.data.statisticsCount.should.be.a('number');
+          done();
+        });
+    });
+
+    it('should return 3 statistics data successfully when query string equal `week`', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/users/me/statistics')
+        .query({ q: 'week' })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.eq(200);
+          res.body.status.should.eq('success');
+          res.body.data.message.should.eq('Operation Successful');
+          res.body.data.statisticsCount.should.eq(3);
+          done();
+        });
+    });
+
+    it('should return 5 statistics data successfully when query string equal `month`', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/users/me/statistics')
+        .query({ q: 'month' })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.eq(200);
+          res.body.status.should.eq('success');
+          res.body.data.message.should.eq('Operation Successful');
+          res.body.data.statisticsCount.should.eq(5);
+          done();
+        });
+    });
+
+    it('should return all statistics data successfully when query string equal `all`', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/users/me/statistics')
+        .query({ q: 'all' })
+        .set('authorization', hashedToken)
+        .end((err, res) => {
+          res.status.should.eq(200);
+          res.body.status.should.eq('success');
+          res.body.data.message.should.eq('Operation Successful');
+          res.body.data.statisticsCount.should.eq(6);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
Implement user should be able to see their reading statistic 

**Description of Task to be completed?**

- write tests for the endpoint
- validate query params
- get the following endpoint working: GET `api/v1/users/me/statistics`

**How should this be manually tested?**

Clone the **repository**
Check out the `ft-user-should-be-able-to-see-their-reading-statistic-159987420` branch
Run `npm install` on your local machine to install required Dependencies
Run database migrations using `npm run migrate`
Run `npm test`
**Using Postman**
Run `npm run seed_data`
Start the server using `npm start`

Go to **GET** `localhost:8000/api/v1/users/me/statics?q=week` with postman
Note: Authentication token is required to access this route. Get that from the login endpoint or signup endpoint

**What are the relevant pivotal tracker stories?**
#159987420