### PR TITLE
feat(user): user can view their stats

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -14,10 +14,10 @@ const url = process.env.BASE_URL;
 
 const { verifiedMessage, successSignupMessage, msgForPasswordReset } = msg;
 const { parsedId } = helpers;
-const {
-  Users, Followings, Interests, Categories
-} = models;
 const { refine, concatUnique } = refineAndConcat;
+const {
+  Users, Followings, Interests, Categories, Articles, Bookmarks, Ratings
+} = models;
 
 const userController = {
   /**
@@ -384,7 +384,15 @@ const userController = {
         message: 'Invalid user details'
       });
     }
-    Users.findOne({ where: { id: userId } })
+    Users.findById(userId, {
+      include: [
+        { model: Articles, as: 'articles' },
+        { model: Ratings, as: 'ratings' },
+        { model: Bookmarks, as: 'bookmarks' },
+        'followed',
+        'follower'
+      ]
+    })
       .then((user) => {
         if (!user || user === undefined) {
           return res.status(404).jsend.fail({

--- a/server/migrations/20180830135814-create-users.js
+++ b/server/migrations/20180830135814-create-users.js
@@ -29,7 +29,8 @@ module.exports = {
       type: Sequelize.STRING
     },
     image: {
-      type: Sequelize.STRING
+      type: Sequelize.STRING,
+      defaultValue: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1536757459/dummy-profile.png'
     },
     premium: {
       type: Sequelize.BOOLEAN

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -85,6 +85,10 @@ const users = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       as: 'articleLikes'
     });
+    Users.hasMany(models.Bookmarks, {
+      foreignKey: 'userId',
+      as: 'bookmarks'
+    });
     Users.belongsTo(models.Roles, {
       foreignKey: 'roleId',
       as: 'role'

--- a/server/seeders/20180909175904-demo-rating.js
+++ b/server/seeders/20180909175904-demo-rating.js
@@ -2,7 +2,25 @@ module.exports = {
   up: queryInterface => queryInterface.bulkInsert('Ratings', [{
     rating: 1,
     userId: 2,
+    articleId: 2,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    rating: 2,
+    userId: 4,
     articleId: 1,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    rating: 3,
+    userId: 4,
+    articleId: 12,
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    rating: 4,
+    userId: 4,
+    articleId: 10,
     createdAt: '2018-09-09',
     updatedAt: '2018-09-09'
   }], {}),

--- a/test/addInterests.spec.js
+++ b/test/addInterests.spec.js
@@ -3,7 +3,7 @@ import chaiHttp from 'chai-http';
 import app from '../server/app';
 
 chai.use(chaiHttp);
-const { assert, expect } = chai;
+const { expect } = chai;
 let userToken1;
 
 describe('TEST ADD INTERESTS/CATEGORY', () => {
@@ -72,7 +72,7 @@ describe('TEST ADD INTERESTS/CATEGORY', () => {
     chai
       .request(app)
       .put('/api/v1/users/interests')
-      .set('authorization', userToken1)
+      .set('Authorization', userToken1)
       .send({ category: '13ab' })
       .end((err, res) => {
         expect(res.body.status).to.equal('fail');

--- a/test/rateArticles.spec.js
+++ b/test/rateArticles.spec.js
@@ -124,7 +124,7 @@ describe('ARTICLES RATING TESTS', () => {
         expect(res.body.status).to.equal('success');
         expect(res.body.data).to.be.a('object');
         expect(res.body.data).to.have.property('averageRating');
-        expect(res.body.data.averageRating).to.equal(3);
+        expect(res.body.data.averageRating).to.equal(2);
         done();
       });
   });
@@ -141,7 +141,7 @@ describe('ARTICLES RATING TESTS', () => {
         expect(res.body.status).to.equal('success');
         expect(res.body.data).to.be.a('object');
         expect(res.body.data).to.have.property('averageRating');
-        expect(res.body.data.averageRating).to.equal(4);
+        expect(res.body.data.averageRating).to.equal(3);
         done();
       });
   });

--- a/test/users.test.spec.js
+++ b/test/users.test.spec.js
@@ -137,6 +137,13 @@ describe('Checks the validity of the user', () => {
         expect(res.body.data.user.firstname).to.equal('John');
         expect(res.body.data.user.lastname).to.equal('Obi');
         expect(res.body.data.user.bio).to.equal('I like to eat');
+        expect(res.body.data.user.articles).to.be.an('array');
+        expect(res.body.data.user.articles[0].title).to.equal('Some other  Article');
+        expect(res.body.data.user.articles[0].slug).to.equal('just-a-sample-article7');
+        expect(res.body.data.user.bookmarks).to.be.an('array');
+        expect(res.body.data.user.ratings).to.be.an('array');
+        expect(res.body.data.user.follower).to.be.an('array');
+        expect(res.body.data.user.followed).to.be.an('array');
         assert.isObject(res.body, 'is an object containing the user details');
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
fetch user stats from the backend

#### Description of Task to be completed?

- Users can view their number of followers
- Users can view the number of articles they have created
- Users can view the number of articles they have bookmarked
- Users can view their ratings on the platform

#### How should this be manually tested?

- Clone the repository.
- Check out the `ft-fetch-user-stat-#161312300`  branch.
- Run npm install on your local machine.
- Run the db migrations using npm run migrate.
- Start the server using npm run start_dev.
- Using postman or any similar. get a token upon registration and use it to test these routes:
  `localhost:8000/api/v1/users/:userId`

#### What are the relevant pivotal tracker stories?
[ #161312300]