### PR TITLE
#161313778 User can add interests

### DIFF
--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -63,8 +63,7 @@ const categoryController = {
           attributes: ['id'],
           model: Articles,
           as: 'count'
-        }
-        ]
+        }]
       })
       .then((category) => {
         if (!category) {

--- a/server/helpers/GetAuthorsOfTheWeekHelpers.js
+++ b/server/helpers/GetAuthorsOfTheWeekHelpers.js
@@ -18,6 +18,7 @@ const GetAuthorsOfTheWeekHelpers = {
       attributes: [
         'id',
         'title',
+        'description',
         'imageUrl',
         'createdAt',
         'userId',

--- a/server/helpers/refineAndConcat.js
+++ b/server/helpers/refineAndConcat.js
@@ -1,0 +1,47 @@
+const refineAndConcat = {
+  /**
+   * @method refine
+   * @description Creates an object containing two arrays: array of ids and an
+   * array of objects with the desired properties
+   * @param {Object} array the array containing objects to destructure
+   * @returns {Object} An object with two array properties
+   */
+  refine: array => array.reduce((acc, item) => {
+    const {
+      id, name, poster, description
+    } = item;
+
+    acc.uniqueCategories.push(id);
+    acc.userInterests.push({
+      id, name, poster, description
+    });
+    return acc;
+  }, { uniqueCategories: [], userInterests: [] }),
+
+  /**
+   * @method concatUnique
+   * @description Creates a new array with the values of the first array
+   * and the destructured values of the second array. It ensures each values
+   * copied from the second array are unique
+   * @param {Object} unique the first array
+   * @param {Object} array1 the first array
+   * @param {Object} array2 the first array
+   * @returns {Object} An object with two array properties
+   */
+  concatUnique: (unique, array1, array2) => array2.reduce((acc, item) => {
+    if (acc.length < 10) {
+      const {
+        id, name, poster, description
+      } = item.dataValues;
+
+      if (!unique.includes(item.dataValues.id)) {
+        acc.push({
+          id, name, poster, description
+        });
+      }
+    }
+    return acc;
+  }, [...array1])
+};
+
+export default refineAndConcat;

--- a/server/middleware/authCheckForCategory.js
+++ b/server/middleware/authCheckForCategory.js
@@ -1,0 +1,37 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import Cryptr from 'cryptr';
+
+dotenv.config();
+
+const secret = process.env.SECRET;
+const cryptr = new Cryptr(secret);
+
+/**
+ * @param  {object} req
+ * @param  {object} res
+ * @param  {object} next
+ * @returns {object} undefined
+ */
+const authCheckForCategory = (req, res, next) => {
+  const token = req.headers.authorization || req.params.token;
+  if (!token) {
+    req.isAuthenticated = false;
+    return next();
+  }
+  // decrypt token with cryptr
+  try {
+    const unHashToken = cryptr.decrypt(token);
+
+    // verify token with jwt
+    jwt.verify(unHashToken, secret, (err, decoded) => {
+      req.currentUser = decoded;
+      req.isAuthenticated = true;
+      return next();
+    });
+  } catch (error) {
+    req.isAuthenticated = false;
+    return next();
+  }
+};
+export default authCheckForCategory;

--- a/server/middleware/usersValidations.js
+++ b/server/middleware/usersValidations.js
@@ -1,4 +1,7 @@
 import helpers from '../helpers/helpers';
+import models from '../models';
+
+const { Categories } = models;
 
 const {
   checkProps,
@@ -101,6 +104,31 @@ const usersValidations = {
         .jsend.fail({
           messages
         });
+    }
+    return next();
+  },
+  /**
+   * @description This method helps validate body of an add interest request
+   * @param  {object} req The request object
+   * @param  {object} res The response object
+   * @param  {object} next the next middleware
+   * @returns {object} undefined
+   */
+  validInterest: async (req, res, next) => {
+    // Check that body contains category property
+    const { valid, invalidMessages } = checkProps(req.body, 'category');
+
+    if (!valid) {
+      return res.status(400).jsend.fail({
+        messages: invalidMessages
+      });
+    }
+
+    // Check that value of category is an integer
+    if (!(/^[0-9]+$/.test(req.body.category))) {
+      return res.status(400).jsend.fail({
+        message: 'Category value must be an integer'
+      });
     }
     return next();
   }

--- a/server/migrations/20180830140233-create-category.js
+++ b/server/migrations/20180830140233-create-category.js
@@ -18,14 +18,6 @@ module.exports = {
       type: Sequelize.TEXT,
       allowNull: false
     },
-    poster: {
-      type: Sequelize.STRING,
-      allowNull: false
-    },
-    description: {
-      type: Sequelize.TEXT,
-      allowNull: false
-    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/server/migrations/20180920153841-create-interests.js
+++ b/server/migrations/20180920153841-create-interests.js
@@ -1,0 +1,37 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Interests', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      }
+    },
+    categoryId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'SET NULL',
+      references: {
+        model: 'Categories',
+        key: 'id',
+        as: 'categoryId'
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Interests')
+};

--- a/server/models/category.js
+++ b/server/models/category.js
@@ -12,14 +12,6 @@ const categories = (sequelize, DataTypes) => {
     description: {
       type: DataTypes.STRING,
       allowNull: false
-    },
-    poster: {
-      type: DataTypes.STRING,
-      allowNull: false
-    },
-    description: {
-      type: DataTypes.TEXT,
-      allowNull: false
     }
   });
 
@@ -31,6 +23,15 @@ const categories = (sequelize, DataTypes) => {
     Categories.hasMany(models.Articles, {
       foreignKey: 'categoryId',
       as: 'count'
+    });
+    Categories.belongsToMany(models.Users, {
+      through: models.Interests,
+      foreignKey: 'categoryId',
+      as: 'interests'
+    });
+    Categories.hasMany(models.Interests, {
+      foreignKey: 'categoryId',
+      as: 'userInterests'
     });
   };
 

--- a/server/models/comments.js
+++ b/server/models/comments.js
@@ -26,6 +26,11 @@ const comments = (sequelize, DataTypes) => {
       as: 'replies'
     });
 
+    Comments.hasMany(models.CommentLikes, {
+      foreignKey: 'commentId',
+      as: 'likes'
+    });
+
     Comments.hasMany(models.CommentHistory, {
       foreignKey: 'commentId',
       as: 'commentHistory'

--- a/server/models/interests.js
+++ b/server/models/interests.js
@@ -1,0 +1,27 @@
+const interests = (sequelize, DataTypes) => {
+  const Interests = sequelize.define('Interests', {
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    categoryId: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    }
+  });
+
+  Interests.associate = (models) => {
+    Interests.belongsTo(models.Users, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE'
+    });
+
+    Interests.belongsTo(models.Categories, {
+      foreignKey: 'categoryId',
+      onDelete: 'CASCADE'
+    });
+  };
+  return Interests;
+};
+
+export default interests;

--- a/server/models/replies.js
+++ b/server/models/replies.js
@@ -15,6 +15,11 @@ const replies = (sequelize, DataTypes) => {
       onDelete: 'CASCADE'
     });
 
+    Replies.hasMany(models.ReplyLikes, {
+      foreignKey: 'replyId',
+      as: 'likes'
+    });
+
     Replies.hasMany(models.ReplyHistory, {
       foreignKey: 'replyId',
       as: 'replyHistory'

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -89,6 +89,15 @@ const users = (sequelize, DataTypes) => {
       foreignKey: 'roleId',
       as: 'role'
     });
+    Users.belongsToMany(models.Categories, {
+      through: models.Interests,
+      foreignKey: 'userId',
+      as: 'categoryInterests'
+    });
+    Users.hasMany(models.Interests, {
+      foreignKey: 'userId',
+      as: 'userInterests'
+    });
   };
   Users.beforeValidate((user) => {
     user.password = user.password ? bcrypt.hashSync(user.password, 8) : null;

--- a/server/routes/categoryRoutes.js
+++ b/server/routes/categoryRoutes.js
@@ -4,6 +4,8 @@ import { multerUploads } from '../config/multer/multerConfig';
 import paginationParamsValidations from '../middleware/paginationParamsValidations';
 import auth from '../middleware/auth';
 import roleValidator from '../middleware/roleValidator';
+import authCheckForCategory from '../middleware/authCheckForCategory';
+import userController from '../controllers/userController';
 
 const {
   isAdmin
@@ -18,9 +20,16 @@ const {
   updateCategory,
   deleteCategory
 } = categoryController;
+const { usersInterests } = userController;
 
 // GET CATEGORY ROUTE
-route.get('/', paginationParamsValidations, allCategory);
+route.get(
+  '/',
+  authCheckForCategory,
+  usersInterests,
+  paginationParamsValidations,
+  allCategory
+);
 route.post('/', auth, isAdmin, multerUploads, createCategory);
 route.get('/:categoryId', paginationParamsValidations, singleCategory);
 route.put('/:categoryId', auth, isAdmin, multerUploads, updateCategory);

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -4,7 +4,9 @@ import auth from '../middleware/auth';
 import roleValidator from '../middleware/roleValidator';
 import usersValidations from '../middleware/usersValidations';
 
-const { validateSignUp, validateLogin, validateNewPassword } = usersValidations;
+const {
+  validateSignUp, validateLogin, validateNewPassword, validInterest
+} = usersValidations;
 const {
   isUser,
   isAdmin
@@ -12,6 +14,7 @@ const {
 
 const userRoutes = express.Router();
 
+userRoutes.put('/interests', auth, isUser, validInterest, userController.addInterests);
 userRoutes.post('/auth/signup', validateSignUp, userController.signUp);
 userRoutes.post('/auth/login', validateLogin, userController.login);
 userRoutes.put('/verify/:token', auth, userController.verify);

--- a/server/seeders/20180909082506-demo-categories.js
+++ b/server/seeders/20180909082506-demo-categories.js
@@ -29,6 +29,68 @@ module.exports = {
     description: 'It has become appallingly obvious that our technology has exceeded our humanity.',
     createdAt: '2018-09-09',
     updatedAt: '2018-09-09'
+  },
+  {
+    name: 'Education',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'Our Education does not need to be reformed; it needs to be rebirthed.',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Agriculture',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'The next generation millionaires would be Agriculturists',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Science',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'Data is the new currency',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Culture',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'South Africa to experience another round of Apatheid',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Career',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'Work-life balance no longer prevails; work-life integration is the new language.',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  },
+  {
+    name: 'Soul',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'How often do you meditate?',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Psychology',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'Magic and mentalism; where do we draw the line?',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Politics',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: '2019 is close, we are set to make yet another wrong decision',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Sports',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'Abrahamovic makes moves towards buying Enyimba Club of Aba',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
+  }, {
+    name: 'Commedy',
+    poster: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1539444927/xuednsow5shjuv28hz4e.png',
+    description: 'Female kangaroo spotted at the White House',
+    createdAt: '2018-09-09',
+    updatedAt: '2018-09-09'
   }]),
 
   down: queryInterface => queryInterface.bulkDelete('Categories')

--- a/server/seeders/20180921285904-demo-interests.js
+++ b/server/seeders/20180921285904-demo-interests.js
@@ -1,0 +1,93 @@
+module.exports = {
+  up: queryInterface => queryInterface.bulkInsert('Interests', [{
+    userId: 1,
+    categoryId: 5,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 1,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 2,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 15,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 3,
+    categoryId: 1,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 4,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 6,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 2,
+    categoryId: 6,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 12,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 7,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 13,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 14,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 1,
+    categoryId: 3,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 3,
+    categoryId: 3,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  },
+  {
+    userId: 3,
+    categoryId: 9,
+    createdAt: '2018-10-08',
+    updatedAt: '2018-10-08'
+  }]),
+  down: queryInterface => queryInterface.bulkDelete('Interests')
+};

--- a/swagger.json
+++ b/swagger.json
@@ -397,6 +397,42 @@
         }
       }
     },
+    "/api/v1/users/interests": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "summary": "Allows user to add categories to his interests",
+        "description": "Allows user to add categories to his interests",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [{
+            "in": "header",
+            "name": "authorization",
+            "description": "user token",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "category to add to list of interests",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/interests"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "you are now following the user"
+          }
+        },
+        "401": {
+          "description": "User access required"
+        }
+      }
+    },
     "/api/v1/articles/{articleId}/like/{likeType}": {
       "post": {
         "tags": [
@@ -1435,7 +1471,7 @@
 					}
 				}
 			}
-	
+
 		}
   },
   "definitions": {
@@ -1932,6 +1968,15 @@
             "example": 1
           }
         }
+      }
+    }
+  },
+  "interests": {
+    "type": "object",
+    "properties": {
+      "category": {
+        "type": "integer",
+        "example": "1"
       }
     }
   }

--- a/test/addInterests.spec.js
+++ b/test/addInterests.spec.js
@@ -1,0 +1,83 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../server/app';
+
+chai.use(chaiHttp);
+const { assert, expect } = chai;
+let userToken1;
+
+describe('TEST ADD INTERESTS/CATEGORY', () => {
+  before('get a user token', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/users/auth/login')
+      .send({
+        email: 'johndoe@gmail.com',
+        password: 'paSS1234'
+      })
+      .end((err, res) => {
+        userToken1 = res.body.data.token;
+        done(err);
+      });
+  });
+  it('should return "Interest added"', (done) => {
+    chai
+      .request(app)
+      .put('/api/v1/users/interests')
+      .set('authorization', userToken1)
+      .send({ category: 13 })
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data.message).to.equal('Interest added');
+        done(err);
+      });
+  });
+  it('should return "Interest already exists"', (done) => {
+    chai
+      .request(app)
+      .put('/api/v1/users/interests')
+      .set('authorization', userToken1)
+      .send({ category: 13 })
+      .end((err, res) => {
+        expect(res.body.status).to.equal('fail');
+        expect(res.body.data.message).to.equal('Interest already exists');
+        done(err);
+      });
+  });
+  it('should return "Unable to add interest; a corresponding category does not exist"', (done) => {
+    chai
+      .request(app)
+      .put('/api/v1/users/interests')
+      .set('authorization', userToken1)
+      .send({ category: 133456 })
+      .end((err, res) => {
+        expect(res.body.status).to.equal('fail');
+        expect(res.body.data.message).to.equal('Unable to add interest; a corresponding category does not exist');
+        done(err);
+      });
+  });
+  it('should fail if category is not provided', (done) => {
+    chai
+      .request(app)
+      .put('/api/v1/users/interests')
+      .set('authorization', userToken1)
+      .send({ categoryyy: 13 })
+      .end((err, res) => {
+        expect(res.body.status).to.equal('fail');
+        expect(res.body.data.messages[0]).to.equal('Please provide category');
+        done(err);
+      });
+  });
+  it('should fail if category value is not an integer', (done) => {
+    chai
+      .request(app)
+      .put('/api/v1/users/interests')
+      .set('authorization', userToken1)
+      .send({ category: '13ab' })
+      .end((err, res) => {
+        expect(res.body.status).to.equal('fail');
+        expect(res.body.data.message).to.equal('Category value must be an integer');
+        done(err);
+      });
+  });
+});

--- a/test/category.spec.js
+++ b/test/category.spec.js
@@ -60,21 +60,6 @@ describe('TEST ALL CATEGORY ENDPOINT', () => {
         done(err);
       });
   });
-  it('should not create a category without image', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/categories')
-      .set('authorization', userToken)
-      .send({
-        name: 'NewCategory',
-        description: 'new description'
-      })
-      .end((err, res) => {
-        expect(res.body.status).to.equal('fail');
-        expect(res.body.data.message);
-        done(err);
-      });
-  });
   it('should not create a category without description', (done) => {
     chai
       .request(app)

--- a/test/dynamicCategory.spec.js
+++ b/test/dynamicCategory.spec.js
@@ -1,0 +1,81 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../server/app';
+
+chai.use(chaiHttp);
+const { assert, expect } = chai;
+let userToken1;
+let userToken2;
+const invalidToken = '864d50ce352424924fa44bf7c3c5d761d939c3135b7e2e412a5466a32a09c423b28a4a3e69859b6858d1d68b505266c828de0fd9840a614f90291d0b68e4fd683dbf9d7deec9b07bdad538f788d322b6fd06aea220c653952c1d73740356735b6fd56f7f7d5c1148fd08e9d99c7cb8d96badc68c298ed7dab4f274bc85defe0c27426aabb84f7d07b8305feff382894f25b0e22288ae3f5f99a584ccf65080aab1b0d346590297afeefe09333880a748fc7f54f97b';
+
+describe('TEST DYNAMIC CATEGORY', () => {
+  before('get a user token', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/users/auth/login')
+      .send({
+        email: 'postman@gmail.com',
+        password: 'Password'
+      })
+      .end((err, res) => {
+        userToken1 = res.body.data.token;
+      });
+
+    chai
+      .request(app)
+      .post('/api/v1/users/auth/login')
+      .send({
+        email: 'johndoe@gmail.com',
+        password: 'paSS1234'
+      })
+      .end((err, res) => {
+        userToken2 = res.body.data.token;
+        done(err);
+      });
+  });
+  it('should return 10 categories for user with 10 or more interests', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/categories')
+      .set('authorization', userToken1)
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data.categories);
+        assert.notExists(res.body.data.metadata);
+        done(err);
+      });
+  });
+  it('should return 10 categories for user with less than 10 interests', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/categories')
+      .set('authorization', userToken2)
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data.categories);
+        assert.notExists(res.body.data.metadata);
+        done(err);
+      });
+  });
+  it('should return default categories if user is not logged in', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/categories')
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        assert.exists(res.body.data.metadata);
+        done(err);
+      });
+  });
+  it('should return default categories if token is invalid', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/categories')
+      .set('authorization', invalidToken)
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        assert.exists(res.body.data.metadata);
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- Adds a new endpoint to enable users add categories to their list of interests
- Modifies GET `/categories` endpoint to return list of categories based on logged in user's interests

#### Description of Task to be completed?
- Added new endpoint PUT `/users/interests/`
- Improved GET `/categories` to return users' categories interests when logged in

#### How should this be manually tested?
Clone the repo, run `npm install`; using postman, hit the `api/v1/users/interests` endpoint to add interests. Hit the `api/v1/categories` get categories based on your selected interests. 

#### What are the relevant pivotal tracker stories?
#161313778