### PR TITLE
#161368505 prevent double password encryption on password update

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -145,7 +145,7 @@ const userController = {
         return res.status(401).jsend.error({ message: 'Verification link not valid' });
       }
       Users.update({
-        password: bcrypt.hashSync(req.body.password, 8)
+        password: req.body.password
       }, {
         where: { id: req.currentUser.id }
       }).then(() => res.status(200).jsend.success({


### PR DESCRIPTION
#### What does this PR do?
fix double password encryption error

#### Description of Task to be completed?
- prevent password encryption when update users' password on successful password reset since the user model is already configured to do this whenever a password is to be updated.

#### How should this be manually tested?

- Clone the repository.
- Check out the `bg-prevent-double-password-encryption-on-password-update-161368505`  branch.
- Run `npm install` on your local machine.
- Run `npm test`

#### What are the relevant pivotal tracker stories?
#161368505