### PR TITLE
Modify signup functionality

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -56,7 +56,7 @@ const userController = {
         });
 
         // THIS FUNCTION SEND AN EMAIL TO USER FOR VERIFICATION OF ACCOUNT
-        mailer.onUserRegistration(user.username, user.email, token);
+        mailer.onUserRegistration(user.username, user.email, req.body.verifyURL, token);
         return res
           .status(201)
           .jsend.success({
@@ -184,9 +184,6 @@ const userController = {
 	 * @returns {object} json response
 	 */
   verify: (req, res) => {
-    // CREATE A TOKEN
-    const token = generateToken(7200, { id: req.currentUser.id, isVerified: true });
-
     let userEmail;
     Users
       .findById(req.currentUser.id)
@@ -210,8 +207,16 @@ const userController = {
 
             // SENDS EMAIL TO USER ON SUCCESSFUL CONFIRMATION
             mailer.emailHelperfunc(verifiedMsg);
+            const token = generateToken('365d', { id: req.currentUser.id, isVerified: true, roleId: user.roleId });
             return res.status(200).jsend.success({
               message: 'Your account is verified successfully',
+              id: user.id,
+              username: user.username,
+              firstname: user.firstname,
+              lastname: user.lastname,
+              email: user.email,
+              roleId: user.roleId,
+              image: user.image,
               token
             });
           })

--- a/server/helpers/utils/eMsgs.js
+++ b/server/helpers/utils/eMsgs.js
@@ -12,10 +12,9 @@ export default {
     <div>
         <h3>Hi ${username},</h3>
         <p>Welcome to Author's Haven, we extend our gratitude to
-            to have you on our platform, But to activate your account please
-            click on this link <br />
+            to have you on our platform. Kindly verify your account with this like to continue. <br />
             <br /> <br />
-            <a href="${url}/api/verify/${token}"
+            <a href="${url}/verifyemail/${token}"
             style="border: 1px solid light-blue; background-color: blue; padding: 10px;
              color: #fff; border-radius:10px; text-decoration: none" > Verify Account
             <a>

--- a/server/helpers/utils/mailer.js
+++ b/server/helpers/utils/mailer.js
@@ -40,13 +40,14 @@ const Mailer = {
    * @memberof Mailer
    * @param {string} username
    * @param {string} email user's email
+   * @param {string} verifyURL the frontend url to use in verification
    * @param {string} token user's token
    * @returns {function} sender
    */
-  onUserRegistration: (username, email, token) => Mailer.sender({
+  onUserRegistration: (username, email, verifyURL, token) => Mailer.sender({
     to: email,
     subject: 'Verify user\'s account',
-    message: msgOnRegistration(username, url, token)
+    message: msgOnRegistration(username, verifyURL || url, token)
   }),
   /**
    * Email Sender helper function

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -5,7 +5,10 @@ import roleValidator from '../middleware/roleValidator';
 import usersValidations from '../middleware/usersValidations';
 
 const {
-  validateSignUp, validateLogin, validateNewPassword, validInterest
+  validateSignUp,
+  validateLogin,
+  validateNewPassword,
+  validInterest,
 } = usersValidations;
 const {
   isUser,

--- a/test/dynamicCategory.spec.js
+++ b/test/dynamicCategory.spec.js
@@ -9,7 +9,7 @@ let userToken2;
 const invalidToken = '864d50ce352424924fa44bf7c3c5d761d939c3135b7e2e412a5466a32a09c423b28a4a3e69859b6858d1d68b505266c828de0fd9840a614f90291d0b68e4fd683dbf9d7deec9b07bdad538f788d322b6fd06aea220c653952c1d73740356735b6fd56f7f7d5c1148fd08e9d99c7cb8d96badc68c298ed7dab4f274bc85defe0c27426aabb84f7d07b8305feff382894f25b0e22288ae3f5f99a584ccf65080aab1b0d346590297afeefe09333880a748fc7f54f97b';
 
 describe('TEST DYNAMIC CATEGORY', () => {
-  before('get a user token', (done) => {
+  before('get user1 token', (done) => {
     chai
       .request(app)
       .post('/api/v1/users/auth/login')
@@ -19,8 +19,10 @@ describe('TEST DYNAMIC CATEGORY', () => {
       })
       .end((err, res) => {
         userToken1 = res.body.data.token;
+        done(err);
       });
-
+  });
+  before('get user2 token', (done) => {
     chai
       .request(app)
       .post('/api/v1/users/auth/login')

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -56,6 +56,7 @@ describe('TEST ALL ENDPOINT', () => {
         .request(app)
         .post('/api/v1/users/auth/signup')
         .send({
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           res.body.should.be.an('object');
@@ -69,7 +70,9 @@ describe('TEST ALL ENDPOINT', () => {
       chai
         .request(app)
         .post('/api/v1/users/auth/login')
-        .send({})
+        .send({
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
+        })
         .end((err, res) => {
           res.body.should.be.an('object');
           res.body.should.have.property('status');
@@ -83,6 +86,7 @@ describe('TEST ALL ENDPOINT', () => {
         .request(app)
         .post('/api/v1/users/auth/login')
         .send({
+          verifyURL: 'https://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           res.body.should.be.an('object');
@@ -99,7 +103,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: '     ',
           email: 'test.tester@email.com',
-          password: 'jdwndsiIUBDIijbikb'
+          password: 'jdwndsiIUBDIijbikb',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           res.body.should.be.an('object');
@@ -119,7 +124,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'IyiKuyoro',
           email: 'test.testeremail.com',
-          password: 'PasswordDD'
+          password: 'PasswordDD',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           res.body.should.be.an('object');
@@ -170,7 +176,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'IyiKuyoro',
           email: 'test.tester@email.com',
-          password: 'asswordlksndv'
+          password: 'asswordlksndv',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           res.body.should.be.an('object');
@@ -219,7 +226,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'IyiKuyoro',
           email: 'test.tester@email.com',
-          password: 'asDndv'
+          password: 'asDndv',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           res.body.should.be.an('object');
@@ -238,7 +246,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'IyiKuyoro',
           email: 'test.tester@email.com',
-          password: 'jdwndsiIUBDIijbikb'
+          password: 'jdwndsiIUBDIijbikb',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           expect(res.body).to.be.an('object');
@@ -253,7 +262,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'IyiKuyoro',
           email: 'test.tester22@email.com',
-          password: 'jdwndsiIUBDIijbikb'
+          password: 'jdwndsiIUBDIijbikb',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           expect(res.body).to.be.an('object');
@@ -307,7 +317,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'JojitoonName',
           email: 'user@gmail.com',
-          password: 'Password'
+          password: 'Password',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           expect(res.body.status).to.equal('success');
@@ -324,7 +335,8 @@ describe('TEST ALL ENDPOINT', () => {
         .send({
           username: 'JojitoonName',
           email: 'user@gmail.com',
-          password: 'Password'
+          password: 'Password',
+          verifyURL: 'http://metis-ah-frontend-stagin.herokuapp.com',
         })
         .end((err, res) => {
           expect(res.body.data.message).to.equal('email already exist!');

--- a/test/users.test.spec.js
+++ b/test/users.test.spec.js
@@ -138,8 +138,8 @@ describe('Checks the validity of the user', () => {
         expect(res.body.data.user.lastname).to.equal('Obi');
         expect(res.body.data.user.bio).to.equal('I like to eat');
         expect(res.body.data.user.articles).to.be.an('array');
-        expect(res.body.data.user.articles[0].title).to.equal('Some other  Article');
-        expect(res.body.data.user.articles[0].slug).to.equal('just-a-sample-article7');
+        expect(res.body.data.user.articles[0].title).to.equal('Top 10 Facebook Advertising Mistakes To Avoid');
+        expect(res.body.data.user.articles[0].slug).to.equal('Top-10-Facebook-Advertising-Mistakes-To-Avoid');
         expect(res.body.data.user.bookmarks).to.be.an('array');
         expect(res.body.data.user.ratings).to.be.an('array');
         expect(res.body.data.user.follower).to.be.an('array');


### PR DESCRIPTION
#### What does this PR do?
Modify signup feature
#### Description of Task to be completed?
- Edit the email body
- Add verify URL support
#### How should this be manually tested?
1. Clone the repository.
2. Reach out to me for the env variables.
3. Checkout the `ft-mailer-159987400` branch.
4. Run `npm install` on your local machine.
5. Run the db migrations using `npm run migrate`.
6. Start the server using `npm run start_dev`.
7. Using postman, try to [POST] to `localhost:8000/api/v1/users/auth/signup`, providing the following as body
  > - username
  > - email
  > - password
  > - verifyURL
#### Any background context you want to provide?
This modification is required for the account verification on the frontend
#### What are the relevant pivotal tracker stories?
#159987400