### PR TITLE
#159987362 implement user can create article only when his firstname and lastname exist

### DIFF
--- a/server/controllers/articleController.js
+++ b/server/controllers/articleController.js
@@ -45,6 +45,19 @@ const articlesController = {
   create: async (req, res) => {
     const fields = req.body;
     let imageUrl = 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1540379606/article-default-image.jpg';
+    const user = await Users.findOne({
+      where: {
+        id: req.currentUser.id
+      },
+      attributes: ['id', 'firstname', 'lastname', 'username']
+    });
+
+    if (!(user.firstname && user.lastname)) {
+      return res.status(403).jsend.fail({
+        message: 'Hi there, We are so sorry to get in your way this time. As much as we appreciate your willingness to share your ideas on our platform, we equally care about how you are identified here. Therefore, we would like you to update your Firstname and Lastname before publishing an article'
+      });
+    }
+
     // check for image exists in the request body
     if (req.file) {
       const file = dataUri(req);

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,4 +1,3 @@
-import bcrypt from 'bcrypt';
 import { config } from 'dotenv';
 import { Op } from 'sequelize';
 import models from '../models';
@@ -125,6 +124,7 @@ const userController = {
    * @returns {object} json response
    */
   resetPassword: (req, res) => {
+    const callbackUrl = req.body.callbackUrl || req.query.callbackUrl || url;
     Users
       .findOne({
         where: { email: req.body.email }
@@ -141,7 +141,7 @@ const userController = {
         mailer.sender({
           to: user.email,
           subject: 'Password reset',
-          message: msgForPasswordReset(user.username, url, token)
+          message: msgForPasswordReset(user.username, callbackUrl, token)
         });
         return res.status(200).jsend.success({
           message: 'Password reset link has been sent to your email',

--- a/server/helpers/utils/eMsgs.js
+++ b/server/helpers/utils/eMsgs.js
@@ -30,9 +30,9 @@ export default {
         <p>You requested for a Password reset on your account. You can use the following link to reset your password:
         <br />
             <br /> <br />
-            <a href="${url}/api/v1/users/api/auth/reset-password/${token}">${url}/api/v1/users/api/auth/reset-password/${token}</a>
+            <a href="${url}/auth/reset-password/${token}">${url}/auth/reset-password/${token}</a>
         </p>
-        <p>If you don’t use this link within 10 minutes, it will expire. To get a new password reset link, visit <a href="${url}/api/v1/users/api/auth/reset-password/">${url}/api/v1/users/api/auth/reset-password/</a></p>
+        <p>If you don’t use this link within 10 minutes, it will expire. To get a new password reset link, visit <a href="${url}/auth/reset-password/">${url}/auth/reset-password/</a></p>
   </div>`;
   }
 };

--- a/server/middleware/inputValidator.js
+++ b/server/middleware/inputValidator.js
@@ -12,8 +12,8 @@ const inputValidator = {
     // REQUIRED FIELDS
     const inputData = {
       title: req.body.title,
-      description: req.body.description,
-      body: req.body.body
+      body: req.body.body,
+      categoryId: req.body.categoryId
     };
 
     const fieldErrors = {};
@@ -22,15 +22,17 @@ const inputValidator = {
     Object.entries(inputData).forEach((field) => {
       const [fieldName, fieldData] = field;
       // CHECKS WHETHER THE REQUIRE FIELDS ARE STRING AND ARE NOT EMPTY
-      if (typeof fieldData === 'string') {
-        if (fieldData.trim() === '') {
-          fieldErrors[fieldName] = `${fieldName} is required`;
+      if (fieldName === 'categoryId') {
+        const integerRegEx = /^\d+$/;
+        if (!integerRegEx.test(fieldData)) {
+          fieldErrors[fieldName] = `${fieldName} is not an integer`;
           isValidData = false;
-        } else {
-          return true;
         }
-      } else {
+      } else if (typeof fieldData === 'string' && fieldData.trim() === '') {
         fieldErrors[fieldName] = `${fieldName} is required`;
+        isValidData = false;
+      } else if (typeof fieldData !== 'string') {
+        fieldErrors[fieldName] = `${fieldName} contains invalid data`;
         isValidData = false;
       }
     });


### PR DESCRIPTION

**What does this PR do?**
Prevent a user whose Firstname and Lastname does not exist from creating articles

**Description of Task to be completed?**

- validate categoryId when creating an article
- add support for callbackUrl for password reset
- prevent a user whose Firstname and Lastname do not exist from creating articles
- response to a user with an aesthetically pleasing message telling him or her to update his first name and last name
- test implementation

**How should this be manually tested?**

Clone the **repository**
Check out the `ft-user-should-have-firstname-and-lastname-before-creating-article-159987362` branch
Run `npm install` on your local machine to install required Dependencies
Run `npm test`

**What are the relevant pivotal tracker stories?**
#159987362