### PR TITLE
161747774 fix the error thrown after profile update

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -375,13 +375,24 @@ const userController = {
         Users.update(updates, {
           where: {
             id
-          },
-          returning: true,
-          plain: true
-        }).then(user => res.status(200).jsend.success({
-          message: 'Your profile has been updated successfully',
-          user
-        }));
+          }
+        }).then(() => {
+          Users.findById(id, {
+            include: [
+              { model: Articles, as: 'articles' },
+              { model: Ratings, as: 'ratings' },
+              { model: Bookmarks, as: 'bookmarks' },
+              'followed',
+              'follower'
+            ]
+          }).then((user) => {
+            delete user.password;
+            return res.status(200).jsend.success({
+              message: 'Your profile has been updated successfully',
+              user
+            });
+          });
+        });
       };
       if (req.file) {
         const file = dataUri(req);

--- a/test/users.test.spec.js
+++ b/test/users.test.spec.js
@@ -94,9 +94,9 @@ describe('Update User Endpoint /api/v1/users/update', () => {
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body).to.be.an('object');
-        expect(res.body.data.user[1].firstname).to.equal('joe');
-        expect(res.body.data.user[1].lastname).to.equal('easy');
-        expect(res.body.data.user[1].bio).to.equal('Hello, here is a brief information about me');
+        expect(res.body.data.user.firstname).to.equal('joe');
+        expect(res.body.data.user.lastname).to.equal('easy');
+        expect(res.body.data.user.bio).to.equal('Hello, here is a brief information about me');
         expect(res.body.data.message).to.equal('Your profile has been updated successfully');
         done();
       });
@@ -117,9 +117,9 @@ describe('Update User Endpoint /api/v1/users/update', () => {
       .type('form')
       .end((err, res) => {
         expect(res).to.have.status(200);
-        expect(res.body.data.user[1].firstname).to.equal('jehonadab');
-        expect(res.body.data.user[1].lastname).to.equal('hehehehehe');
-        expect(res.body.data.user[1].bio).to.equal('Here is a brief information about me');
+        expect(res.body.data.user.firstname).to.equal('jehonadab');
+        expect(res.body.data.user.lastname).to.equal('hehehehehe');
+        expect(res.body.data.user.bio).to.equal('Here is a brief information about me');
         expect(res.body.data.message).to.equal('Your profile has been updated successfully');
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
Fix and prevent the application from crashing when users update their profile on the frontend
#### Description of Task to be completed?
- modify update profile to return the user's profile stat
- modify API docs to reflect changes to get all articles endpoint
- test get all articles endpoint

#### How should this be manually tested?

- Clone the repository.
- Check out the `bg-error-thrown-on-profile-update-#161747774` branch.
- Run npm install on your local machine.
- Run the DB migrations using npm run migrate.
- Start the server using npm run start_dev.
- Using postman or any similar. get a token upon registration and use it to test these routes:
  `localhost:8000/api/v1/users/update`

#### What are the relevant pivotal tracker stories?
[ #161747774](https://www.pivotaltracker.com/story/show/161747774)