### PR TITLE
feat(get-comments): get all comments for an article

### DIFF
--- a/server/helpers/commentHelpers.js
+++ b/server/helpers/commentHelpers.js
@@ -40,15 +40,17 @@ const commentHelpers = {
 
       await historyModel.create(historyOptions);
       const user = await Users.findById(userComment.userId, {
-        attributes: ['id', 'username', 'firstname', 'lastname', 'createdAt', 'updatedAt']
+        attributes: ['id', 'username', 'firstname', 'lastname', 'image']
       });
+      comment.dataValues.user = user;
+
       notify.multiEventNotifications(
         response,
         request,
         articleId,
-        'articleLikes', 'commented on the article:'
+        'commented on the article:'
       );
-      return response.status(201).jsend.success({ comment, user });
+      return response.status(201).jsend.success({ comment });
     } catch (error) {
       return response.status(500).jsend.error({
         message: 'There was a problem',

--- a/server/helpers/notify.js
+++ b/server/helpers/notify.js
@@ -56,7 +56,8 @@ const notify = {
           notify.push(
             `notify-${followed.dataValues.id}`,
             `channel-${followed.dataValues.id}`,
-            { message: `${user.dataValues.username} created an article titled: ${notifiable.title}` });
+            { message: `${user.dataValues.username} created an article titled: ${notifiable.title}` }
+          );
         });
         if (bulkData.length !== 0) {
           notify.createNotifications(res, bulkData);
@@ -122,7 +123,7 @@ const notify = {
           notify.createNotifications(res, bulkData);
         }
       })
-      .catch((err) => { res.status(500).jsend.error({ message: err }); });
+      .catch(err => err.message);
   },
 
   /**
@@ -143,7 +144,8 @@ const notify = {
           notifiable: 'user',
           notifiableId: user.id
         }]);
-        notify.push(`notify-${userId}`,
+        notify.push(
+          `notify-${userId}`,
           `channel-${userId}`,
           { message: `${user.username} is now following you` }
         );

--- a/server/models/comments.js
+++ b/server/models/comments.js
@@ -13,6 +13,7 @@ const comments = (sequelize, DataTypes) => {
   Comments.associate = (models) => {
     Comments.belongsTo(models.Users, {
       foreignKey: 'userId',
+      as: 'user',
       onDelete: 'CASCADE'
     });
 

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -30,7 +30,9 @@ const {
   reportArticle
 } = articleController;
 
-const { addComment, updateComment, updateReply } = commentController;
+const {
+  addComment, updateComment, updateReply, getComments
+} = commentController;
 const {
   validateComments,
   validateLikeObject,
@@ -56,6 +58,7 @@ articleRoutes.get('/featured', getFeaturedArticles);
 
 // Comment routes
 // Add comment
+articleRoutes.get('/:articleId/comments', checkParams.id, paginationParamsValidations, getComments);
 articleRoutes.post(
   '/:articleId/comments',
   auth,

--- a/test/comments.spec.js
+++ b/test/comments.spec.js
@@ -10,6 +10,30 @@ let token;
 const content = 56743;
 
 describe('Tests for Comments and Replies', () => {
+  describe('Get comments tests', () => {
+    it('should return comments successfully', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles/1/comments')
+        .end((err, res) => {
+          res.status.should.equal(200);
+          res.body.status.should.equal('success');
+          done();
+        });
+    });
+    it('should fail when ID is out of range', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/articles/18978769707867879/comments')
+        .end((err, res) => {
+          res.status.should.eq(500);
+          res.body.status.should.equal('fail');
+          res.body.data.message.should.equal('Something went wrong, unable to process request');
+          done();
+        });
+    });
+  });
+
   describe('Create comment tests', () => {
     before((done) => {
       chai
@@ -93,7 +117,7 @@ describe('Tests for Comments and Replies', () => {
           content: 'Your post was not inspiring.'
         })
         .end((err, res) => {
-          res.body.data.should.have.property('user');
+          res.body.data.comment.should.have.property('user');
           res.body.data.comment.content.should.equal('Your post was not inspiring.');
           done(err);
         });


### PR DESCRIPTION
#### What does this PR do?
Fetch all comments for an article

#### Description of tasks to be completed
- get fetch all comments for an article working
- implement pagination support for these comments
- bug fix: comment creation not triggering notification

**How should this be manually tested?**
- Clone the **repository**
- Check out the `ft-get-comments-for-an-article-161883088` branch
- Run `npm install` on your local machine to install required Dependencies
- Run database migrations using `npm run migrate`
- Run `npm test`
**Using Postman**
Run `npm run seed_data`
Start the server using `npm start`

Go to **GET** `http://localhost:8000/api/v1/articles/2/comments` with postman
Note: **2** in the above url is the ID of the article you want to comment on. Also, ensure  to have `postgreSOL` setup and have its url exported to the command-line before running migrations and seeding data.

#### Relevant Pivotal tracker stories
#161883088