### PR TITLE
#161949876 Users can view their active like or dislike on an article

### DIFF
--- a/server/controllers/articleController.js
+++ b/server/controllers/articleController.js
@@ -127,8 +127,8 @@ const articlesController = {
       })
       .spread((data, created) => {
         if (!created) {
-          data.like = liked;
-          data.dislike = disliked;
+          data.liked = liked;
+          data.disliked = disliked;
           data.save().catch(err => res.status(500).jsend.error({
             message: 'Request could not be processed',
             error: err.message
@@ -143,6 +143,30 @@ const articlesController = {
         return res.status(200).jsend.success({ data, message });
       }).catch(() => res.status(401).jsend.fail({
         message: 'Article not found'
+      }));
+  },
+  /**
+   * @description allows users to check if they've already like an article before
+   * @param  {Object} req the request object
+   * @param  {Object} res the response object
+   * @returns {Object} json response
+   */
+  getUserReaction: (req, res) => {
+    ArticleLikes
+      .find({
+        where: {
+          userId: req.currentUser.id,
+          articleId: Number(req.params.articleId)
+        }
+      }).then((userReaction) => {
+        if (!userReaction) {
+          return res.status(404).jsend.fail({});
+        }
+        return res.status(200).jsend.success({
+          userReaction
+        });
+      }).catch(err => res.status(500).jsend.error({
+        message: err
       }));
   },
 

--- a/server/helpers/notify.js
+++ b/server/helpers/notify.js
@@ -56,7 +56,8 @@ const notify = {
           notify.push(
             `notify-${followed.dataValues.id}`,
             `channel-${followed.dataValues.id}`,
-            { message: `${user.dataValues.username} created an article titled: ${notifiable.title}` });
+            { message: `${user.dataValues.username} created an article titled: ${notifiable.title}` }
+          );
         });
         if (bulkData.length !== 0) {
           notify.createNotifications(res, bulkData);
@@ -143,7 +144,8 @@ const notify = {
           notifiable: 'user',
           notifiableId: user.id
         }]);
-        notify.push(`notify-${userId}`,
+        notify.push(
+          `notify-${userId}`,
           `channel-${userId}`,
           { message: `${user.username} is now following you` }
         );

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -18,6 +18,7 @@ const articleRoutes = express.Router();
 
 const {
   like,
+  getUserReaction,
   getArticles,
   getFeaturedArticles,
   getPopularArticlesForTheWeek,
@@ -130,6 +131,15 @@ articleRoutes.post(
   checkParams.likeType,
   isUser,
   like
+);
+
+// check if current user has like or dislike an article
+articleRoutes.get(
+  '/:articleId/like',
+  auth,
+  checkParams.id,
+  isUser,
+  getUserReaction
 );
 
 // REPORT ARTICLE ENDPOINT

--- a/test/articles.spec.js
+++ b/test/articles.spec.js
@@ -398,24 +398,59 @@ describe('Articles likes test', () => {
         done();
       });
   });
-
-  it('should return you unliked the article', (done) => {
+  it('should return true for liked article', (done) => {
     chai
       .request(app)
-      .post('/api/v1/articles/1/like/unlike')
+      .get('/api/v1/articles/1/like')
       .set('authorization', hashedToken)
       .send()
       .end((err, res) => {
         expect(res.body.status).to.equal('success');
-        expect(res.body.data.message).to.equal('you unliked the article');
+        expect(res.body.data.userReaction.liked).to.equal(true);
         done();
       });
   });
 
+  it('should return you unliked the article', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/articles/1/like/dislike')
+      .set('authorization', hashedToken)
+      .send()
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data.message).to.equal('you disliked the article');
+        done();
+      });
+  });
+  it('should return true for disliked articles', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/1/like')
+      .set('authorization', hashedToken)
+      .send()
+      .end((err, res) => {
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data.userReaction.disliked).to.equal(true);
+        done();
+      });
+  });
+  it('should return an empty object when no like was found', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/100000/like')
+      .set('authorization', hashedToken)
+      .send()
+      .end((err, res) => {
+        expect(res.body.status).to.equal('fail');
+        expect(res.body.data).to.be.an('Object');
+        done();
+      });
+  });
   it('should return you article not found', (done) => {
     chai
       .request(app)
-      .post('/api/v1/articles/100/like/unlike')
+      .post('/api/v1/articles/100/like/dislike')
       .set('authorization', hashedToken)
       .send()
       .end((err, res) => {


### PR DESCRIPTION
### What does this PR do?
- Allows users to view their active like or dislike on an article
- Fix bug on like and dislike functionality

### Description of tasks to be completed
When a user revisits an article they've already liked or dislike:
- they should be able to see an active like or dislike button.

### How can this be manually tested
- clone the project
- `git checkout ft-users-can-view-active-like-dislike-#161949876`
- run `npm install`
- run `npm run start_dev` to start the dev server
- From postman
  - make a `GET` request to `localhost:8000/api/v1/articles/:articleId/like/` to fetch the like and dislike for the logged in user

### What are the relevant Pivotal tracker stories
[161949876](https://www.pivotaltracker.com/story/show/161949876)

